### PR TITLE
feat: improve gas

### DIFF
--- a/contracts/libraries/LoanLibrary.sol
+++ b/contracts/libraries/LoanLibrary.sol
@@ -105,8 +105,6 @@ library LoanLibrary {
         LoanTerms terms;
         // The current state of the loan
         LoanState state;
-        // Timestamp representing absolute due date date of the loan
-        uint256 dueDate;
         // installment loan specific
         // Start date of the loan, using block.timestamp - for determining installment period
         uint256 startDate;

--- a/contracts/test/MockLoanCore.sol
+++ b/contracts/test/MockLoanCore.sol
@@ -95,7 +95,6 @@ contract MockLoanCore is ILoanCore, Initializable, AccessControlUpgradeable, UUP
         loans[loanId] = LoanLibrary.LoanData(
             terms,
             LoanLibrary.LoanState.Active,
-            block.timestamp + terms.durationSecs,
             block.timestamp,
             terms.principal,
             0,

--- a/test/LoanCore.ts
+++ b/test/LoanCore.ts
@@ -620,7 +620,7 @@ describe("LoanCore", () => {
                 .startLoan(await lender.getAddress(), await borrower.getAddress(), terms);
             const receipt = await tx.wait();
             const gasUsed = receipt.gasUsed;
-            expect(gasUsed.toString()).to.equal("665166");
+            expect(gasUsed.toString()).to.equal("642491");
         });
     });
 
@@ -786,7 +786,7 @@ describe("LoanCore", () => {
             const tx = await loanCore.connect(borrower).repay(loanId);
             const receipt = await tx.wait();
             const gasUsed = receipt.gasUsed;
-            expect(gasUsed.toString()).to.equal("241508");
+            expect(gasUsed.toString()).to.equal("239983");
         });
     });
 
@@ -951,7 +951,7 @@ describe("LoanCore", () => {
             const tx = await loanCore.connect(borrower).claim(loanId);
             const receipt = await tx.wait();
             const gasUsed = receipt.gasUsed;
-            expect(gasUsed.toString()).to.equal("201000");
+            expect(gasUsed.toString()).to.equal("199536");
         });
     });
 

--- a/test/utils/types.ts
+++ b/test/utils/types.ts
@@ -43,7 +43,6 @@ export interface ItemsPayload {
 export interface LoanData {
     terms: LoanTerms;
     state: LoanState;
-    dueDate: BigNumberish;
     startDate: BigNumberish;
     balance: BigNumber;
     balancePaid: BigNumber;


### PR DESCRIPTION
- use single key for collateralInUse to save an sload
- remove unnecessary full sload of loan data
- remove unnnecessary dueDate prop which can be derived from startDate
+ durations, saving several storage operations