### PR TITLE
Test coverage v2

### DIFF
--- a/contracts/ERC721PermitUpgradeable.sol
+++ b/contracts/ERC721PermitUpgradeable.sol
@@ -11,6 +11,7 @@ import "@openzeppelin/contracts-upgradeable/utils/cryptography/ECDSAUpgradeable.
 import "@openzeppelin/contracts-upgradeable/utils/CountersUpgradeable.sol";
 
 import "./interfaces/IERC721PermitUpgradeable.sol";
+import "hardhat/console.sol";
 
 import { ERC721P_DeadlineExpired, ERC721P_NotTokenOwner, ERC721P_InvalidSignature } from "./errors/LendingUtils.sol";
 
@@ -113,6 +114,7 @@ abstract contract ERC721PermitUpgradeable is
         bytes32 s
     ) public virtual override {
         if (block.timestamp > deadline) revert ERC721P_DeadlineExpired(deadline);
+        console.log(owner, ERC721Upgradeable.ownerOf(tokenId));
         if (owner != ERC721Upgradeable.ownerOf(tokenId)) revert ERC721P_NotTokenOwner(owner);
 
         bytes32 structHash = keccak256(

--- a/contracts/ERC721PermitUpgradeable.sol
+++ b/contracts/ERC721PermitUpgradeable.sol
@@ -11,7 +11,6 @@ import "@openzeppelin/contracts-upgradeable/utils/cryptography/ECDSAUpgradeable.
 import "@openzeppelin/contracts-upgradeable/utils/CountersUpgradeable.sol";
 
 import "./interfaces/IERC721PermitUpgradeable.sol";
-import "hardhat/console.sol";
 
 import { ERC721P_DeadlineExpired, ERC721P_NotTokenOwner, ERC721P_InvalidSignature } from "./errors/LendingUtils.sol";
 
@@ -114,7 +113,6 @@ abstract contract ERC721PermitUpgradeable is
         bytes32 s
     ) public virtual override {
         if (block.timestamp > deadline) revert ERC721P_DeadlineExpired(deadline);
-        console.log(owner, ERC721Upgradeable.ownerOf(tokenId));
         if (owner != ERC721Upgradeable.ownerOf(tokenId)) revert ERC721P_NotTokenOwner(owner);
 
         bytes32 structHash = keccak256(

--- a/contracts/OriginationController.sol
+++ b/contracts/OriginationController.sol
@@ -612,8 +612,8 @@ contract OriginationController is
         // and less than 10,000% (1e8 basis points)
         if (terms.interestRate < 1e18 || terms.interestRate > 1e26) revert OC_InterestRate(terms.interestRate);
 
-        // number of installments must be an even number.
-        if (terms.numInstallments % 2 != 0 || terms.numInstallments > 1_000_000)
+        // number of installments must be between 2 and 1000.
+        if (terms.numInstallments == 1 || terms.numInstallments > 1_000)
             revert OC_NumberInstallments(terms.numInstallments);
 
         // signature must not have already expired

--- a/contracts/OriginationController.sol
+++ b/contracts/OriginationController.sol
@@ -609,7 +609,7 @@ contract OriginationController is
         if (terms.durationSecs < 3600 || terms.durationSecs > 94_608_000) revert OC_LoanDuration(terms.durationSecs);
 
         // interest rate must be greater than or equal to 0.01%
-        // and less than 10,000% (1e8 basis points)
+        // and less than 10,000% (1e6 basis points)
         if (terms.interestRate < 1e18 || terms.interestRate > 1e26) revert OC_InterestRate(terms.interestRate);
 
         // number of installments must be between 2 and 1000.

--- a/contracts/OriginationController.sol
+++ b/contracts/OriginationController.sol
@@ -609,7 +609,7 @@ contract OriginationController is
         if (terms.durationSecs < 3600 || terms.durationSecs > 94_608_000) revert OC_LoanDuration(terms.durationSecs);
 
         // interest rate must be greater than or equal to 0.01%
-        // and less than 10,000% (1e6 basis points)
+        // and less than 10,000% (1e8 basis points)
         if (terms.interestRate < 1e18 || terms.interestRate > 1e26) revert OC_InterestRate(terms.interestRate);
 
         // number of installments must be between 2 and 1000.

--- a/notes/TODOs.md
+++ b/notes/TODOs.md
@@ -7,6 +7,27 @@ Final Cleanup:
 - Run prettier
 - Delete notes/ folder
 
+Evan:
+
+> V2 Protocol Planning/ Progress:
+
+- (DONE) Installment Claims
+- (DONE) Rollover Review
+- (IN PROGRESS) Test coverage
+ - need rebase after rollovers merge
+ - remove modulus(2) require statement and try a 1 installment loan.
+   - modify:
+   ```
+   if (terms.numInstallments % 2 != 0 || terms.numInstallments > 1_000_000)
+           revert OC_NumberInstallments(terms.numInstallments);
+   ```
+   to
+   ```
+   if (terms.numInstallments <= 1 || terms.numInstallments > 1_000)
+           revert OC_NumberInstallments(terms.numInstallments);
+   ```
+   To allow for loan terms anywhere between 2 - 1000 installment periods. One not allowed, this is a legacy loan type.
+
 Mouzayan:
 
 - Upgradeability and dependency architecture\

--- a/test/AssetVault.ts
+++ b/test/AssetVault.ts
@@ -784,5 +784,14 @@ describe("AssetVault", () => {
                 );
             });
         });
+
+        describe("Introspection", function () {
+            it("should return true for declaring support for eip165 interface contract", async () => {
+                const { nft } = await loadFixture(fixture);
+                // https://eips.ethereum.org/EIPS/eip-165#test-cases
+                expect(await nft.supportsInterface("0x01ffc9a7")).to.be.true;
+                expect(await nft.supportsInterface("0xfafafafa")).to.be.false;
+            });
+        });
     });
 });

--- a/test/AssetVault.ts
+++ b/test/AssetVault.ts
@@ -34,6 +34,9 @@ interface TestContext {
 }
 
 describe("AssetVault", () => {
+    /**
+     * Creates a vault instance using the vault factory
+     */
     const createVault = async (factory: VaultFactory, user: Signer): Promise<AssetVault> => {
         const tx = await factory.connect(user).initializeBundle(await user.getAddress());
         const receipt = await tx.wait();
@@ -511,7 +514,7 @@ describe("AssetVault", () => {
                 const amount = hre.ethers.utils.parseUnits("50", 18);
                 await deposit(mockERC20, vault, amount, user);
 
-                await vault.enableWithdraw();
+                await vault.connect(user).enableWithdraw();
                 await expect(vault.connect(user).withdrawERC20(mockERC20.address, await user.getAddress()))
                     .to.emit(vault, "WithdrawERC20")
                     .withArgs(await user.getAddress(), mockERC20.address, await user.getAddress(), amount)

--- a/test/CallWhitelist.ts
+++ b/test/CallWhitelist.ts
@@ -256,5 +256,17 @@ describe("CallWhitelist", () => {
             await whitelist.remove(mockERC20.address, selector);
             expect(await whitelist.isWhitelisted(mockERC20.address, selector)).to.be.false;
         });
+        it("add again after removing", async () => {
+            const { whitelist, mockERC20 } = await loadFixture(fixture);
+            const selector = mockERC20.interface.getSighash("mint");
+
+            expect(await whitelist.isWhitelisted(mockERC20.address, selector)).to.be.false;
+            await whitelist.add(mockERC20.address, selector);
+            expect(await whitelist.isWhitelisted(mockERC20.address, selector)).to.be.true;
+            await whitelist.remove(mockERC20.address, selector);
+            expect(await whitelist.isWhitelisted(mockERC20.address, selector)).to.be.false;
+            await whitelist.add(mockERC20.address, selector);
+            expect(await whitelist.isWhitelisted(mockERC20.address, selector)).to.be.true;
+        });
     });
 });

--- a/test/LoanCore.ts
+++ b/test/LoanCore.ts
@@ -936,6 +936,29 @@ describe("LoanCore", () => {
             await expect(loanCore.connect(borrower).claim(loanId, BigNumber.from(0))).to.be.revertedWith("Pausable: paused");
         });
 
+        it("pause, unPause, make tx", async () => {
+            const {
+                mockERC20,
+                loanId,
+                loanCore,
+                other:lender,
+                user: borrower,
+                terms,
+                blockchainTime,
+            } = await setupLoan();
+            await mockERC20.connect(borrower).mint(loanCore.address, terms.principal.add(terms.interestRate));
+
+            await blockchainTime.increaseTime(360001);
+            await loanCore.connect(borrower).pause();
+
+            await blockchainTime.increaseTime(100);
+            await loanCore.connect(borrower).unpause();
+
+            await expect(loanCore.connect(borrower).claim(loanId, BigNumber.from(0)))
+            .to.emit(loanCore, "LoanClaimed")
+            .withArgs(loanId);
+        });
+
         it("gas [ @skip-on-coverage ]", async () => {
             const {
                 mockERC20,

--- a/test/OriginationController.ts
+++ b/test/OriginationController.ts
@@ -1169,7 +1169,7 @@ describe("OriginationController", () => {
                     ),
             ).to.be.revertedWith("LC_NonceUsed");
         });
-        it.only("Initializes a loan with permit and items", async () => {
+        it("Initializes a loan with permit and items", async () => {
           const { originationController, mockERC20, mockERC721, vaultFactory, user: lender, other: borrower, lenderPromissoryNote, borrowerPromissoryNote } = ctx;
 
           const bundleId = await initializeBundle(vaultFactory, borrower);
@@ -1208,7 +1208,7 @@ describe("OriginationController", () => {
              vaultFactory.address,
              await vaultFactory.name(),
              permitData,
-             lender,
+             borrower,
          );
 
           const sig = await createLoanItemsSignature(
@@ -1219,8 +1219,6 @@ describe("OriginationController", () => {
               borrower,
               "2",
           );
-
-          console.log("BORROWER ADDR", await borrower.getAddress())
 
           await approve(mockERC20, lender, originationController.address, loanTerms.principal);
           await vaultFactory.connect(borrower).approve(originationController.address, bundleId);

--- a/test/PromissoryNote.ts
+++ b/test/PromissoryNote.ts
@@ -290,6 +290,10 @@ describe("PromissoryNote", () => {
 
             approved = await promissoryNote.getApproved(promissoryNoteId);
             expect(approved).to.equal(await other.getAddress());
+            //check nonce was incremented to one
+            expect(await promissoryNote.nonces(await user.getAddress())).to.equal(1);
+            //test coverage checking domain separator
+            expect(await promissoryNote.DOMAIN_SEPARATOR());
         });
 
         it("rejects if given owner is not real owner", async () => {
@@ -413,6 +417,15 @@ describe("PromissoryNote", () => {
                     s,
                 ),
             ).to.be.revertedWith("ERC721P_DeadlineExpired");
+        });
+    });
+
+    describe("Introspection", function () {
+        it("should return true for declaring support for eip165 interface contract", async () => {
+            const { borrowerPromissoryNote } = await loadFixture(fixture);
+            // https://eips.ethereum.org/EIPS/eip-165#test-cases
+            expect(await borrowerPromissoryNote.supportsInterface("0x01ffc9a7")).to.be.true;
+            expect(await borrowerPromissoryNote.supportsInterface("0xfafafafa")).to.be.false;
         });
     });
 });

--- a/test/RepaymentController.ts
+++ b/test/RepaymentController.ts
@@ -395,5 +395,21 @@ describe("RepaymentController", () => {
         await repaymentController.connect(borrower).repay(loanId);
 
         expect(await mockERC20.balanceOf(borrower.address)).to.equal(0);
+
+        // LC_BalanceGTZero unreachable?
+        await mint(mockERC20, borrower, ethers.utils.parseEther("1"));
+        await mockERC20.connect(borrower).approve(repaymentController.address, ethers.utils.parseEther("1"));
+        await expect(repaymentController.connect(borrower).repay(loanId)).to.be.revertedWith("LC_InvalidState");
+
     });
+});
+
+describe("RepaymentController revert branches", () => {
+    it("Get full interest with invaild rate, should revert.", async () => {
+        const context = await loadFixture(fixture);
+        const { repaymentController } = context;
+        await expect(repaymentController.getFullInterestAmount(ethers.utils.parseEther("100"), ethers.utils.parseEther("0.9")))
+         .to.be.revertedWith("FIAC_InterestRate");
+    });
+
 });

--- a/test/VaultFactory.ts
+++ b/test/VaultFactory.ts
@@ -198,6 +198,11 @@ describe("VaultFactory", () => {
 
             approved = await factory.getApproved(bundleId);
             expect(approved).to.equal(await other.getAddress());
+
+            //check nonce was incremented to one
+            expect(await factory.nonces(await user.getAddress())).to.equal(1);
+            //test coverage checking domain separator
+            expect(await factory.DOMAIN_SEPARATOR());
         });
 
         it("rejects if given owner is not real owner", async () => {


### PR DESCRIPTION
Tests added for complete test coverage. 

One protocol related change in the OriginationController:  
```
 if (terms.numInstallments % 2 != 0 || terms.numInstallments > 1_000_000)
         revert OC_NumberInstallments(terms.numInstallments);
 ```
 changed to
 ```
 if (terms.numInstallments <= 1 || terms.numInstallments > 1_000)
         revert OC_NumberInstallments(terms.numInstallments);
 ``` 

This is to allow for any number of installments between 2-1000, with 0 also being allowed indicating a legacy loan type (without installments).