### PR TITLE
[QSP-1]: update rollover logic to set correct balancePaid

### DIFF
--- a/contracts/LoanCore.sol
+++ b/contracts/LoanCore.sol
@@ -307,8 +307,8 @@ contract LoanCore is
 
             data.lateFeesAccrued += lateFees;
             data.numInstallmentsPaid += uint24(numMissedPayments) + 1;
-            data.balance = 0;
             data.balancePaid += data.balance + interestDue + lateFees;
+            data.balance = 0;
         }
 
         _burnLoanNotes(oldLoanId);


### PR DESCRIPTION
Small change - make sure to update `balancePaid` with `data.balance` before zeroing out `data.balance`.

Does not affect any loan logic, just stored data, since `balancePaid` is only informational.