### PR TITLE
[QSP-3]: Enforce maximum possible fee for origination and rollover

### DIFF
--- a/contracts/FeeController.sol
+++ b/contracts/FeeController.sol
@@ -54,7 +54,7 @@ contract FeeController is AccessControlEnumerable, IFeeController, Ownable {
      * @param _rolloverFee          The new rollover fee, in bps.
      */
     function setRolloverFee(uint256 _rolloverFee) external override onlyOwner {
-        if (_rolloverFee > MAX_ORIGINATION_FEE) revert FC_FeeTooLarge();
+        if (_rolloverFee > MAX_ROLLOVER_FEE) revert FC_FeeTooLarge();
 
         rolloverFee = _rolloverFee;
         emit UpdateRolloverFee(_rolloverFee);

--- a/contracts/FeeController.sol
+++ b/contracts/FeeController.sol
@@ -6,6 +6,8 @@ import "@openzeppelin/contracts/access/AccessControlEnumerable.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "./interfaces/IFeeController.sol";
 
+import { FC_FeeTooLarge } from "./errors/Lending.sol";
+
 /**
  * @title FeeController
  * @author Non-Fungible Technologies, Inc.
@@ -19,6 +21,11 @@ import "./interfaces/IFeeController.sol";
  */
 contract FeeController is AccessControlEnumerable, IFeeController, Ownable {
     // ============================================ STATE ==============================================
+
+    /// @dev Global maximum fees, preventing attacks by owners
+    ///      which drain principal.
+    uint256 public constant MAX_ORIGINATION_FEE = 1000;
+    uint256 public constant MAX_ROLLOVER_FEE = 500;
 
     /// @dev Fee for origination - default is 0.5%
     uint256 private originationFee = 50;
@@ -34,6 +41,8 @@ contract FeeController is AccessControlEnumerable, IFeeController, Ownable {
      * @param _originationFee       The new origination fee, in bps.
      */
     function setOriginationFee(uint256 _originationFee) external override onlyOwner {
+        if (_originationFee > MAX_ORIGINATION_FEE) revert FC_FeeTooLarge();
+
         originationFee = _originationFee;
         emit UpdateOriginationFee(_originationFee);
     }
@@ -45,6 +54,8 @@ contract FeeController is AccessControlEnumerable, IFeeController, Ownable {
      * @param _rolloverFee          The new rollover fee, in bps.
      */
     function setRolloverFee(uint256 _rolloverFee) external override onlyOwner {
+        if (_rolloverFee > MAX_ORIGINATION_FEE) revert FC_FeeTooLarge();
+
         rolloverFee = _rolloverFee;
         emit UpdateRolloverFee(_rolloverFee);
     }
@@ -59,8 +70,6 @@ contract FeeController is AccessControlEnumerable, IFeeController, Ownable {
     function getOriginationFee() public view override returns (uint256) {
         return originationFee;
     }
-
-    // ========================================= FEE GETTERS ===========================================
 
     /**
      * @notice Get the current origination fee in bps.

--- a/contracts/errors/Lending.sol
+++ b/contracts/errors/Lending.sol
@@ -335,3 +335,11 @@ error PN_BurningRole(address caller);
  * @notice No token transfers while contract is in paused state.
  */
 error PN_ContractPaused();
+
+// ==================================== Fee Controller ======================================
+/// @notice All errors prefixed with FC_, to separate from other contracts in the protocol.
+
+/**
+ * @notice Caller attempted to set a fee which is larger than the global maximum.
+ */
+error FC_FeeTooLarge();

--- a/test/FeeController.ts
+++ b/test/FeeController.ts
@@ -34,14 +34,20 @@ describe("FeeController", () => {
         describe("setOriginationFee", () => {
             it("reverts if sender does not have admin role", async () => {
                 const { feeController, other } = await loadFixture(fixture);
-                await expect(feeController.connect(other).setOriginationFee(1234)).to.be.reverted;
+                await expect(feeController.connect(other).setOriginationFee(1234)).to.be.revertedWith("Ownable: caller is not the owner");
+            });
+
+            it("reverts if new fee is over the maximum", async () => {
+                const { feeController, user } = await loadFixture(fixture);
+                await expect(feeController.connect(user).setOriginationFee(10_000))
+                    .to.be.revertedWith("FC_FeeTooLarge");
             });
 
             it("sets origination fee", async () => {
                 const { feeController, user } = await loadFixture(fixture);
-                await expect(feeController.connect(user).setOriginationFee(1234))
+                await expect(feeController.connect(user).setOriginationFee(123))
                     .to.emit(feeController, "UpdateOriginationFee")
-                    .withArgs(1234);
+                    .withArgs(123);
             });
         });
 
@@ -60,6 +66,26 @@ describe("FeeController", () => {
 
                 const originationFee = await feeController.connect(user).getOriginationFee();
                 expect(originationFee).to.equal(newFee);
+            });
+        });
+
+        describe("setRolloverFee", () => {
+            it("reverts if sender does not have admin role", async () => {
+                const { feeController, other } = await loadFixture(fixture);
+                await expect(feeController.connect(other).setRolloverFee(1234)).to.be.revertedWith("Ownable: caller is not the owner");
+            });
+
+            it("reverts if new fee is over the maximum", async () => {
+                const { feeController, user } = await loadFixture(fixture);
+                await expect(feeController.connect(user).setRolloverFee(10_000))
+                    .to.be.revertedWith("FC_FeeTooLarge");
+            });
+
+            it("sets origination fee", async () => {
+                const { feeController, user } = await loadFixture(fixture);
+                await expect(feeController.connect(user).setRolloverFee(123))
+                    .to.emit(feeController, "UpdateRolloverFee")
+                    .withArgs(123);
             });
         });
 


### PR DESCRIPTION
Also `roku-med-3` in roku's report.

Set constant max fee values and revert if `FeeController` owner attempts to set a larger fee.

Add tests to check for these cases.