### PR TITLE
[QSP-7]: add discussion of privileged roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,3 +112,27 @@ This is version 2 of the protocol. Version 1 of the protocol can be found [here]
 * The typehash for signatures has changed to reflecting these new fields: see `_TOKEN_ID_TYPEHASH` in OriginationController.sol.
 * Any repayment functions now take `loanId` as parameters instead of the appropriate note IDs. Note that in V2 these values are guaranteed to be the same.
 * `PunkRouter` is no longer supported. CryptoPunks should be directly transferred to asset vaults for deposits.
+
+# Privileged Roles and Access
+
+The Arcade.xyz lending protocol has myriad functionality available to contract owners. This functionality represents a tradeoff between immutability, operational security, and recoverability in the case of exploit.
+
+Arcade.xyz's policy is to assign any ownership functions to a multisig with a subset of signers external to the team, and a signing threshold such that one external signer must always participate. This precludes internal collusion, "rogue insider" attacks, and malicious upgrades. Other groups deploying these contracts should implement their own policies.
+
+* `CallWhitelist.sol` is `Ownable` and has a defined owner, who can update a whitelist of allowed calls. This whitelist is global to every `AssetVault` deployed through the `VaultFactory`. In plain terms, the `CallWhitelist` owner has the ability to change the allowed functions an `AssetVault` can call. In practice, ownership follows the stated ownership policy above.
+* `VaultFactory.sol` is `AccessControl` and upgradeable. The only role `AccessControl` manages is the `DEFAULT_ADMIN_ROLE`. Callers must possess the `DEFAULT_ADMIN_ROLE` in order to perform an upgrade. Since the contract is upgradeable, the contract owner can update the code of the contract as they see fit, which may:
+    * affect future deployments of `AssetVault`, causing them to be deployed with different code
+    * change the way ownership is defined for `AssetVault`, including pre-existing owners
+    * add additional functionality to the factory
+In practice, ownership (and thus access to upgradeability) follows the stated ownership policy above.
+* `FeeController.sol` is `Ownable` and has a defined owner, who can update the protocol fees. In practice, this contract may be administered by an internal Arcade.xyz team without external signers, since it defines business logic around fees and has limited functionality. Internal constants define maximum fees that the protocol can set, preventing an attack whereby funds are drained via setting fees to 100%. Note that `LoanCore.sol` can switch out to a different FeeController entirely.
+* `LoanCore.sol` is `AccessControl` and has a number of defined access roles:
+    * The `ORIGINATOR_ROLE` is the only role allowed to access any functions which originate loans. In practice this role is granted to another smart contract, `OriginationController.sol`, which performs necessary checks and validation before starting loans.
+    * The `REPAYER_ROLE` is the only role allowed to access any functions which affect the loan lifecycle of currently active loans (repayment or default claims). In practice this role is granted to another smart contract, `RepaymentController.sol`, which performs necessary checks, calculations and validation before starting loans.
+    * The `FEE_CLAIMER_ROLE` is the only role allowed to update references to the `FeeController`, and claim any accumulated protocol fees. In practice this role will be assigned to an internal multisig, since withdrawing accumulated fees is a regular aspect of protocol operation.
+    * The `DEFAULT_ADMIN_ROLE` is the role allowed to perform contract upgrades. Since `LoanCore` is upgradeable, any aspect of the core protocol may change. Users should be aware that since `LoanCore` custodies collateral, contract upgrades may change access of security of the collateral. In practice, ownership (and thus access to upgradeability) follows the stated ownership policy above. `LoanCore` upgradeability is a last-resort feature to only be used in emergencies.
+* `OriginationController.sol` is `Ownable` and upgradeable. The defined owner is the only role which can perform a contract upgrade. Since the contract is upgradeable, the contract owner can update the code of the contract as they see fit, which may:
+    * change, add, or, remove validation checks for originating loans
+    * change signature schemes for loan consent
+Upgradeability is enabled in order to preserve approval state held by the contract. In practice, ownership (and thus access to upgradeability) follows the stated ownership policy above.
+* `PromissoryNote.sol` is `Ownable`, and the owner has exclusive permission to initialize the contract with a reference to an address which is allowed to mint and burn note tokens. In practice, this permission will be granted to `LoanCore.sol`. Since `initialize` is called on deployment and can only be called once, in practice, the owner will be the deployer.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The Vault Factory is an ERC721 that tracks ownership of Asset Vault contracts (s
 VaultFactory token involves deploying a new AssetVault clone, and assigning the token's ID to the uint160 derived
 from the clone's address.
 
-Token ownership represents ownership of the underlying clone contract and be transferred - however, to prevent
+Token ownership represents ownership of the underlying clone contract and can be transferred - however, to prevent
 frontrunning attacks, any vault with withdrawals enabled cannot be transferred (see [AssetVault](#AssetVault)).
 ### AssetVault
 
@@ -45,7 +45,7 @@ vaults. The contract owner can choose to add or remove target addresses and func
 
 ### ItemsVerifier
 
-A contract that parses a payload of calldata and a target AssetVault, and decodes the in order to use it
+A contract that parses a payload of calldata and a target AssetVault, and decodes the payload in order to use it
 for logic proving or disproving defined predicates about the vault. The ItemsVerifier decodes the calldata
 as a list of required items the vault must hold in order for its predicates to pass. In the future, other contracts
 implementing `IArcadeSignatureVerifier` can support other calldata formats and associated validation logic.


### PR DESCRIPTION
Add a `README.md` describing the contracts with a discussion of privileged roles. QSP team can read only the "Privileged Roles and Access" section if they wish to avoid extra scope.

Note: `RepaymentController.sol` was not discussed because we will be removing its inheritance of `AccessControl`. It's not used so it's not needed, although it wasn't mentioned in the audit. We'll remove it after the final report is delivered.