### PR TITLE
[QSP-Tests]: use dynamic addresses for role tests to ensure always passing

### DIFF
--- a/.solcover.js
+++ b/.solcover.js
@@ -20,9 +20,5 @@ module.exports = {
     mnemonic,
   },
   skipFiles: ["mocks", "test", "external"],
-  mocha: {
-    grep: "@skip-on-coverage",
-    invert: true,
-  },
   configureYulOptimizer: true,
 };

--- a/test/PromissoryNote.ts
+++ b/test/PromissoryNote.ts
@@ -235,7 +235,7 @@ describe("PromissoryNote", () => {
             await expect(PromissoryNote.connect(signers[0]).initialize(signers[0].address)).to.not.be.reverted;
 
             await expect(PromissoryNote.connect(signers[1]).setPaused(true)).to.be.revertedWith(
-                "AccessControl: account 0xadd93e738a415c5248f7cb044fcfc71d86b18572 is missing role 0xa49807205ce4d355092ef5a8a18f56e8913cf4a201fbe287825b095693c21775",
+                `AccessControl: account ${signers[1].address.toLowerCase()} is missing role 0xa49807205ce4d355092ef5a8a18f56e8913cf4a201fbe287825b095693c21775`,
             );
         });
 
@@ -247,7 +247,7 @@ describe("PromissoryNote", () => {
             await expect(PromissoryNote.connect(signers[0]).initialize(signers[0].address)).to.not.be.reverted;
 
             await expect(PromissoryNote.connect(signers[1]).setPaused(false)).to.be.revertedWith(
-                "AccessControl: account 0xadd93e738a415c5248f7cb044fcfc71d86b18572 is missing role 0xa49807205ce4d355092ef5a8a18f56e8913cf4a201fbe287825b095693c21775",
+                `AccessControl: account ${signers[1].address.toLowerCase()} is missing role 0xa49807205ce4d355092ef5a8a18f56e8913cf4a201fbe287825b095693c21775`,
             );
         });
 


### PR DESCRIPTION
Hardcoded addresses in tests which check for `AccessControl` reverts were failing due to dependence on a specific mnemonic. This change updates those addresses to be read dynamically.

Also removed the gas tests, which are brittle and not used in practice (we use `REPORT_GAS=true` and Tenderly to perform gas profiling and analysis).