### PR TITLE
[QSP-BP]: Adopt best practice recommendations

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ vault's contract address. Asset Vaults can hold ETH, ERC20s, ERC721, ERC1155, an
 
 The owner of a vault can also place an arbitrary `call` via the vault, in order to access utility derived from
 NFTs held in the vault. Other contracts can delegate the ability to make calls. In practice, an Asset Vault custodied
-by LoanCore delegates calling ability to the borrower, such that the borrower can accesss utility for a collateralized
+by LoanCore delegates calling ability to the borrower, such that the borrower can access utility for a collateralized
 vault. The protocol maintains a list of allowed calls (see [CallWhitelist](#CallWhitelist)).
 
 ### CallWhitelist
@@ -89,7 +89,7 @@ from the old and new loan, and collects any needed balance from the responsible 
 
 The repayment controller handles all lifecycle progression for currently active loans - this contract has exclusive
 permission to call functions in `LoanCore` which repay loans, in whole or in part, or claim collateral on loan defaults.
-This contract is repsonsible for validating repayments inputs, calculating owed amounts, and collecting owed amounts
+This contract is responsible for validating repayments inputs, calculating owed amounts, and collecting owed amounts
 from the relevant counterparty. This contract also contains a convenience function for calculating the total amount
 due on any loan at a given time.
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ vaults. The contract owner can choose to add or remove target addresses and func
 A contract that parses a payload of calldata and a target AssetVault, and decodes the payload in order to use it
 for logic proving or disproving defined predicates about the vault. The ItemsVerifier decodes the calldata
 as a list of required items the vault must hold in order for its predicates to pass. In the future, other contracts
-implementing `IArcadeSignatureVerifier` can support other calldata formats and associated validation logic.
+implementing `ISignatureVerifier` can support other calldata formats and associated validation logic.
 
 ## Loan Lifecycle
 

--- a/contracts/LoanCore.sol
+++ b/contracts/LoanCore.sol
@@ -625,7 +625,7 @@ contract LoanCore is
     }
 
     /*
-     * @dev Mint a borrower and lender note together - eiaser to make sure
+     * @dev Mint a borrower and lender note together - easier to make sure
      *      they are synchronized.
      *
      * @param loanId                The token ID to mint.

--- a/contracts/LoanCore.sol
+++ b/contracts/LoanCore.sol
@@ -452,8 +452,7 @@ contract LoanCore is
      * @param nonce                 The nonce to consume.
      */
     function cancelNonce(uint160 nonce) external override {
-        address user = _msgSender();
-        _useNonce(user, nonce);
+        _useNonce(_msgSender(), nonce);
     }
 
     // ========================================= VIEW FUNCTIONS =========================================

--- a/contracts/OriginationController.sol
+++ b/contracts/OriginationController.sol
@@ -225,7 +225,7 @@ contract OriginationController is
             address verifier = itemPredicates[i].verifier;
             if (!isAllowedVerifier(verifier)) revert OC_InvalidVerifier(verifier);
 
-            if (!IArcadeSignatureVerifier(verifier).verifyPredicates(itemPredicates[i].data, vault)) {
+            if (!ISignatureVerifier(verifier).verifyPredicates(itemPredicates[i].data, vault)) {
                 revert OC_PredicateFailed(verifier, itemPredicates[i].data, vault);
             }
         }
@@ -410,7 +410,7 @@ contract OriginationController is
             address verifier = itemPredicates[i].verifier;
             if (!isAllowedVerifier(verifier)) revert OC_InvalidVerifier(verifier);
 
-            if (!IArcadeSignatureVerifier(verifier).verifyPredicates(itemPredicates[i].data, vault)) {
+            if (!ISignatureVerifier(verifier).verifyPredicates(itemPredicates[i].data, vault)) {
                 revert OC_PredicateFailed(verifier, itemPredicates[i].data, vault);
             }
         }
@@ -584,7 +584,7 @@ contract OriginationController is
      *         for instance, an upgradeable third-party verifier controlled by a borrower could be maliciously
      *         upgraded to approve an empty bundle.
      *
-     * @param verifier              The specified verifier contract, should implement IArcadeSignatureVerifier.
+     * @param verifier              The specified verifier contract, should implement ISignatureVerifier.
      * @param isAllowed             Whether the specified contract should be allowed.
      */
     function setAllowedVerifier(address verifier, bool isAllowed) public override onlyOwner {
@@ -599,7 +599,7 @@ contract OriginationController is
      * @notice Batch update for verification whitelist, in case of multiple verifiers
      *         active in production.
      *
-     * @param verifiers             The list of specified verifier contracts, should implement IArcadeSignatureVerifier.
+     * @param verifiers             The list of specified verifier contracts, should implement ISignatureVerifier.
      * @param isAllowed             Whether the specified contracts should be allowed, respectively.
      */
     function setAllowedVerifierBatch(address[] calldata verifiers, bool[] calldata isAllowed) external override {

--- a/contracts/RepaymentController.sol
+++ b/contracts/RepaymentController.sol
@@ -16,7 +16,6 @@ pragma solidity ^0.8.11;
  */
 
 import "@openzeppelin/contracts/utils/Context.sol";
-import "@openzeppelin/contracts/access/AccessControl.sol";
 import "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
@@ -40,23 +39,19 @@ import { RC_CannotDereference, RC_InvalidState, RC_NoPaymentDue, RC_OnlyLender, 
  * claim collateral on a defaulted loan. It is this contract's responsibility
  * to verify loan conditions before calling LoanCore.
  */
-contract RepaymentController is IRepaymentController, InstallmentsCalc, AccessControl {
+contract RepaymentController is IRepaymentController, InstallmentsCalc, Context {
     using SafeERC20 for IERC20;
 
     // ============================================ STATE ===============================================
 
     ILoanCore private loanCore;
-    IPromissoryNote private borrowerNote;
     IPromissoryNote private lenderNote;
 
     constructor(
-        ILoanCore _loanCore,
-        IPromissoryNote _borrowerNote,
-        IPromissoryNote _lenderNote
+        ILoanCore _loanCore
     ) {
         loanCore = _loanCore;
-        borrowerNote = _borrowerNote;
-        lenderNote = _lenderNote;
+        lenderNote = loanCore.lenderNote();
     }
 
     // ==================================== LIFECYCLE OPERATIONS ========================================

--- a/contracts/errors/Lending.sol
+++ b/contracts/errors/Lending.sol
@@ -193,6 +193,13 @@ error IV_NonPositiveAmount20(address asset, uint256 amount);
 error RC_CannotDereference(uint256 target);
 
 /**
+ * @notice Ensure valid loan state for loan lifceycle operations.
+ *
+ * @param state                         Current state of a loan according to LoanState enum.
+ */
+error RC_InvalidState(LoanLibrary.LoanState state);
+
+/**
  * @notice Repayment has already been completed for this loan without installments.
  */
 error RC_NoPaymentDue();

--- a/contracts/interfaces/ISignatureVerifier.sol
+++ b/contracts/interfaces/ISignatureVerifier.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.11;
 
 import "../libraries/LoanLibrary.sol";
 
-interface IArcadeSignatureVerifier {
+interface ISignatureVerifier {
     // ============== Collateral Verification ==============
 
     function verifyPredicates(bytes calldata predicates, address vault) external view returns (bool);

--- a/contracts/verifiers/ItemsVerifier.sol
+++ b/contracts/verifiers/ItemsVerifier.sol
@@ -43,7 +43,7 @@ import { IV_ItemMissingAddress, IV_InvalidCollateralType, IV_NonPositiveAmount11
  * - All multi-item signatures assume AND - any optional expressed by OR
  *      can be implemented by simply signing multiple separate signatures.
  */
-contract ArcadeItemsVerifier is IArcadeSignatureVerifier {
+contract ArcadeItemsVerifier is ISignatureVerifier {
     using SafeCast for int256;
 
     /// @dev Enum describing the collateral type of a signature item

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
         "@nomiclabs/hardhat-ethers": "^2.0.1",
         "@nomiclabs/hardhat-etherscan": "^2.1.7",
         "@nomiclabs/hardhat-waffle": "^2.0.1",
-        "@openzeppelin/contracts": "^4.0.0",
+        "@openzeppelin/contracts": "4.3.2",
         "@typechain/ethers-v5": "^5.0.0",
         "@typechain/hardhat": "^1.0.1",
         "@types/chai": "^4.2.13",
@@ -93,7 +93,7 @@
         "bootstrap-no-loans": "npx hardhat --network localhost run scripts/bootstrap-state-no-loans.ts"
     },
     "dependencies": {
-        "@openzeppelin/contracts-upgradeable": "^4.5.2",
+        "@openzeppelin/contracts-upgradeable": "4.5.2",
         "@openzeppelin/hardhat-upgrades": "^1.17.0"
     }
 }

--- a/test/Installments.ts
+++ b/test/Installments.ts
@@ -113,7 +113,7 @@ const fixture = async (): Promise<TestContext> => {
     await originationController.deployed();
 
     const repaymentController = <RepaymentController>(
-        await deploy("RepaymentController", admin, [loanCore.address, borrowerNote.address, lenderNote.address])
+        await deploy("RepaymentController", admin, [loanCore.address])
     );
     await repaymentController.deployed();
     const updateRepaymentControllerPermissions = await loanCore.grantRole(REPAYER_ROLE, repaymentController.address);

--- a/test/Installments.ts
+++ b/test/Installments.ts
@@ -332,7 +332,7 @@ describe("Installments", () => {
             ).to.be.revertedWith("RC_CannotDereference");
         });
 
-        it("returns 0 for an already closed loan", async () => {
+        it("reverts for an already closed loan", async () => {
             const context = await loadFixture(fixture);
             const { repaymentController, mockERC20, borrower, lender, blockchainTime } = context;
             const { loanId } = await initializeInstallmentLoan(
@@ -359,15 +359,11 @@ describe("Installments", () => {
                 .to.emit(mockERC20, "Transfer")
                 .withArgs(await borrower.getAddress(), repaymentController.address, ethers.utils.parseEther("102.5"));
 
-            const installmentRes = await repaymentController
-                .connect(borrower)
-                .callStatic.getInstallmentMinPayment(loanId);
-            const minInterestDue = installmentRes[0];
-            const lateFees = installmentRes[1];
-            const numMissedPayments2 = installmentRes[2].toNumber();
-            expect(minInterestDue).to.equal(0);
-            expect(lateFees).to.equal(0);
-            expect(numMissedPayments2).to.equal(0);
+            await expect(
+                repaymentController
+                    .connect(borrower)
+                    .getInstallmentMinPayment(loanId)
+            ).to.be.revertedWith("RC_InvalidState");
         });
     });
 
@@ -490,7 +486,7 @@ describe("Installments", () => {
 
             await expect(
                 repaymentController.connect(borrower).repayPart(loanId, ethers.utils.parseEther("102.5")),
-            ).to.be.revertedWith("LC_InvalidState");
+            ).to.be.revertedWith("RC_InvalidState");
         });
 
         it("Fast Forward to 2nd period. Verify missed payments equals one.", async () => {

--- a/test/Integration.ts
+++ b/test/Integration.ts
@@ -84,7 +84,7 @@ describe("Integration", () => {
         const mockERC20 = <MockERC20>await deploy("MockERC20", admin, ["Mock ERC20", "MOCK"]);
 
         const repaymentController = <RepaymentController>(
-            await deploy("RepaymentController", admin, [loanCore.address, borrowerNote.address, lenderNote.address])
+            await deploy("RepaymentController", admin, [loanCore.address])
         );
         await repaymentController.deployed();
         const updateRepaymentControllerPermissions = await loanCore.grantRole(

--- a/test/PromissoryNote.ts
+++ b/test/PromissoryNote.ts
@@ -113,9 +113,7 @@ describe("PromissoryNote", () => {
 
         const repaymentController = <RepaymentController>(
             await deploy("RepaymentController", signers[0], [
-                loanCore.address,
-                borrowerNote.address,
-                lenderNote.address,
+                loanCore.address
             ])
         );
         await repaymentController.deployed();

--- a/test/RepaymentController.ts
+++ b/test/RepaymentController.ts
@@ -403,7 +403,7 @@ describe("RepaymentController", () => {
         // LC_BalanceGTZero unreachable?
         await mint(mockERC20, borrower, ethers.utils.parseEther("1"));
         await mockERC20.connect(borrower).approve(repaymentController.address, ethers.utils.parseEther("1"));
-        await expect(repaymentController.connect(borrower).repay(loanId)).to.be.revertedWith("LC_InvalidState");
+        await expect(repaymentController.connect(borrower).repay(loanId)).to.be.revertedWith("RC_InvalidState");
     });
 });
 

--- a/test/RepaymentController.ts
+++ b/test/RepaymentController.ts
@@ -103,7 +103,7 @@ const fixture = async (): Promise<TestContext> => {
     await originationController.deployed();
 
     const repaymentController = <RepaymentController>(
-        await deploy("RepaymentController", admin, [loanCore.address, borrowerNote.address, lenderNote.address])
+        await deploy("RepaymentController", admin, [loanCore.address])
     );
 
     await repaymentController.deployed();

--- a/test/Rollovers.ts
+++ b/test/Rollovers.ts
@@ -98,7 +98,7 @@ describe("Rollovers", () => {
         const mockERC721 = <MockERC721>await deploy("MockERC721", admin, ["Mock ERC721", "MOCK"]);
 
         const repaymentController = <RepaymentController>(
-            await deploy("RepaymentController", admin, [loanCore.address, borrowerNote.address, lenderNote.address])
+            await deploy("RepaymentController", admin, [loanCore.address])
         );
         await repaymentController.deployed();
         const updateRepaymentControllerPermissions = await loanCore.grantRole(

--- a/yarn.lock
+++ b/yarn.lock
@@ -1224,12 +1224,12 @@
     widest-line "^3.1.0"
     wrap-ansi "^4.0.0"
 
-"@openzeppelin/contracts-upgradeable@^4.5.2":
+"@openzeppelin/contracts-upgradeable@4.5.2":
   version "4.5.2"
   resolved "https://registry.yarnpkg.com/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.5.2.tgz#90d9e47bacfd8693bfad0ac8a394645575528d05"
   integrity sha512-xgWZYaPlrEOQo3cBj97Ufiuv79SPd8Brh4GcFYhPgb6WvAq4ppz8dWKL6h+jLAK01rUqMRp/TS9AdXgAeNvCLA==
 
-"@openzeppelin/contracts@^4.0.0":
+"@openzeppelin/contracts@4.3.2":
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.3.2.tgz#ff80affd6d352dbe1bbc5b4e1833c41afd6283b6"
   integrity sha512-AybF1cesONZStg5kWf6ao9OlqTZuPqddvprc0ky7lrUVOjXeKpmQ2Y9FK+6ygxasb+4aic4O5pneFBfwVsRRRg==


### PR DESCRIPTION
Numbered recommendations:

_1. Version 4.6 of Open Zeppelin's Initializable.sol contract introduces some new functionality, including a new pattern for preventing unauthorized implementation contract initialization. The new pattern is mentioned in their documentation here._

Won't fix - upgrading `@openzeppelin/contracts-upgradeable` to 4.6.0 (we are currently on 4.5.2) breaks type exporting in a way that would take too much complexity to fix.

_2. At L447 of LoanCore, it would be more efficient to directly pass `_msgSender()` in place of user._

Fixed.

_3. Rename ISignatureVerifier.sol to IArcadeSignatureVerifier or vice versa._

Fixed, it should be `ISignatureVerifier` everywhere now.

_4. RepaymentController.sol, getInstallmentMinPayment does not check whether the LoanState of the Loan is Repaid._

_5. The constructor of RepaymentController should reference the borrowerNote and lenderNote of LoanCore._

Fixed. The reference to `borrowerNote` was removed, since it was not used. Additionally `AccessControl` was removed as a dependency and replaced with `Context`.

_6. Checking the state of a loan should be consolidated into either the Controller contracts or LoanCore. Currently, OriginationController checks the state at rolloverLoan._

Added a check in `getInstallmentMinPayment`, but we are going to keep the redundant checks in both controller and core in place (also relevant to 4). We see benefits to having both: The checks in the controller "fail early" and save gas for users, and the checks in `LoanCore` provide redundancy in case we use a different contract in the `REPAYER_ROLE` that might have bugs.
