### PR TITLE
[roku-minor-1]: Lending.sol errors fixed. Comments updated and LoanCore imports updated.

### DIFF
--- a/contracts/LoanCore.sol
+++ b/contracts/LoanCore.sol
@@ -20,6 +20,7 @@ import "./interfaces/ILoanCore.sol";
 import "./InstallmentsCalc.sol";
 import "./PromissoryNote.sol";
 import "./vault/OwnableERC721.sol";
+<<<<<<< HEAD
 import {
     LC_ZeroAddress,
     LC_ReusedNote,
@@ -31,6 +32,9 @@ import {
     LC_NonceUsed,
     LC_LoanNotDefaulted
 } from "./errors/Lending.sol";
+=======
+import { LC_ZeroAddress, LC_CollateralInUse, LC_CollateralNotInUse, LC_InvalidState, LC_NotExpired, LC_NonceUsed, LC_LoanNotDefaulted } from "./errors/Lending.sol";
+>>>>>>> 06ee51f (fix(roku-minor-1): error comments fixed, 1 error removed, origination controller comment fix)
 
 /**
  * @title LoanCore

--- a/contracts/OriginationController.sol
+++ b/contracts/OriginationController.sol
@@ -636,7 +636,7 @@ contract OriginationController is
         if (terms.durationSecs < 3600 || terms.durationSecs > 94_608_000) revert OC_LoanDuration(terms.durationSecs);
 
         // interest rate must be greater than or equal to 0.01%
-        // and less than 10,000% (1e8 basis points)
+        // and less than 10,000% (1e6 basis points)
         if (terms.interestRate < 1e18 || terms.interestRate > 1e24) revert OC_InterestRate(terms.interestRate);
 
         // number of installments must be between either 0, or between 2 and 1000.

--- a/contracts/errors/Lending.sol
+++ b/contracts/errors/Lending.sol
@@ -42,7 +42,7 @@ error OC_LoanDuration(uint256 durationSecs);
 error OC_InterestRate(uint256 interestRate);
 
 /**
- * @notice Loan terms must have even number of installments and intallment periods must be < 1000000.
+ * @notice Number of installment periods must be greater than 1 and less than or equal to 1000.
  *
  * @param numInstallments               Number of installment periods in loan.
  */
@@ -290,14 +290,7 @@ error LC_InvalidState(LoanLibrary.LoanState state);
 error LC_NotExpired(uint256 dueDate);
 
 /**
- * @notice Loan duration has not expired.
- *
- * @param returnAmount                  Total amount due for entire loan repayment.
- */
-error LC_BalanceGTZero(uint256 returnAmount);
-
-/**
- * @notice Loan duration has not expired.
+ * @notice User and the specified nonce have already been used.
  *
  * @param user                          Address of collateral owner.
  * @param nonce                         Represents the number of transactions sent by address.

--- a/test/RepaymentController.ts
+++ b/test/RepaymentController.ts
@@ -400,7 +400,6 @@ describe("RepaymentController", () => {
 
         expect(await mockERC20.balanceOf(borrower.address)).to.equal(0);
 
-        // LC_BalanceGTZero unreachable?
         await mint(mockERC20, borrower, ethers.utils.parseEther("1"));
         await mockERC20.connect(borrower).approve(repaymentController.address, ethers.utils.parseEther("1"));
         await expect(repaymentController.connect(borrower).repay(loanId)).to.be.revertedWith("RC_InvalidState");


### PR DESCRIPTION
Lending.sol comments fixed and unused errors removed. Comments updated in OriginationController and LoanCore errors, LoanCore imports also updated.

For the last bullet point related to the OriginationController revert statement. This comment has been updated, but not to the suggested value. The comment is supposed to show the difference between 1e18 and 1e24 (min/max interest rate values).