### PR TITLE
[roku-high-1]: Defaults for installment loans

### DIFF
--- a/contracts/LoanCore.sol
+++ b/contracts/LoanCore.sol
@@ -243,14 +243,18 @@ contract LoanCore is
         LoanLibrary.LoanData memory data = loans[loanId];
         // ensure valid initial loan state when starting loan
         if (data.state != LoanLibrary.LoanState.Active) revert LC_InvalidState(data.state);
-        // for legacy loans (currentInstallmentPeriod == 0) ensure lender is claiming
-        // after the loan has ended and if so, block.timstamp must be greater than the dueDate.
-        // for installment loan types (currentInstallmentPeriod > 0), check if the loan
-        // is in default, if not, revert.
-        if (data.terms.numInstallments == 0) {
-            uint256 dueDate = data.startDate + data.terms.durationSecs;
+        // All loans are able to be claimed after the loanIds dueDate.
+        // First check that the call happens after the dueDate and if not verify the loanId
+        // is an installment loan type and passes verification of missing greater than
+        // 40% the total number of installments.
+        uint256 dueDate = data.startDate + data.terms.durationSecs;
+        if (data.terms.numInstallments == 0 || dueDate < block.timestamp) {
             if (dueDate > block.timestamp) revert LC_NotExpired(dueDate);
-        } else {
+        }
+        else {
+            // verify installment loan type, not legacy loan (safety check)
+            if (data.terms.numInstallments == 0) revert LC_NotExpired(dueDate);
+            // verify >40% total installments have been missed
             _verifyDefaultedLoan(data.terms.numInstallments, data.numInstallmentsPaid, currentInstallmentPeriod);
         }
 

--- a/test/Installments.ts
+++ b/test/Installments.ts
@@ -664,6 +664,7 @@ describe("Installments", () => {
 
             await expect(repaymentController.connect(borrower).repay(loanId)).to.be.revertedWith("RC_HasInstallments");
         });
+
         it("Scenario: numInstallments: 8, durationSecs: 36000, principal: 100, interest: 10%. Repay minimum on first payment.", async () => {
             const context = await loadFixture(fixture);
             const { repaymentController, mockERC20, borrower, lender, blockchainTime, loanCore } = context;
@@ -1579,6 +1580,7 @@ describe("Installments", () => {
                 await expect(borrowerBalanceAfter).to.equal(borrowerBalanceBefore.sub(ethers.utils.parseEther("7.5")));
                 await expect(lenderBalanceAfter).to.equal(lenderBalanceBefore.add(ethers.utils.parseEther("7.5")));
             });
+
             it("Send zero as amount for repayPart call.", async () => {
                 const context = await loadFixture(fixture);
                 const { repaymentController, mockERC20, loanCore, borrower, lender, blockchainTime } = context;
@@ -1908,6 +1910,7 @@ describe("Installments", () => {
             expect(borrowerBalanceAfter.sub(borrowerBalanceBefore)).to.equal(0);
             expect(lenderBalanceAfter.sub(lenderBalanceBefore)).to.equal(1);
         });
+
         it("Scenario: numInstallments: 2, durationSecs: 36000. Borrower calls claim after first missed installment, should revert.", async () => {
             const context = await loadFixture(fixture);
             const { repaymentController, loanCore, mockERC20, borrower, lender, blockchainTime } = context;
@@ -1929,6 +1932,7 @@ describe("Installments", () => {
             // have lender call claim on the collateral
             await expect(repaymentController.connect(borrower).claim(loanId)).to.be.revertedWith("RC_OnlyLender");
         });
+
         it("Scenario: numInstallments: 2, durationSecs: 36000. Claim in first installment period should revert.", async () => {
             const context = await loadFixture(fixture);
             const { repaymentController, loanCore, mockERC20, vaultFactory, borrower, lender, blockchainTime } =
@@ -1957,6 +1961,7 @@ describe("Installments", () => {
             expect(borrowerBalanceAfter.sub(borrowerBalanceBefore)).to.equal(0);
             expect(lenderBalanceAfter.sub(lenderBalanceBefore)).to.equal(0);
         });
+
         it("Scenario: numInstallments: 4, durationSecs: 36000. Claim after first missed installment, should revert.", async () => {
             const context = await loadFixture(fixture);
             const { repaymentController, loanCore, mockERC20, vaultFactory, borrower, lender, blockchainTime } =
@@ -1985,6 +1990,7 @@ describe("Installments", () => {
             expect(borrowerBalanceAfter.sub(borrowerBalanceBefore)).to.equal(0);
             expect(lenderBalanceAfter.sub(lenderBalanceBefore)).to.equal(0);
         });
+
         it("Scenario: numInstallments: 4, durationSecs: 36000. Claim after 40% the loan duration, should revert still second installment period.", async () => {
             const context = await loadFixture(fixture);
             const { repaymentController, loanCore, mockERC20, vaultFactory, borrower, lender, blockchainTime } =
@@ -2013,6 +2019,7 @@ describe("Installments", () => {
             expect(borrowerBalanceAfter.sub(borrowerBalanceBefore)).to.equal(0);
             expect(lenderBalanceAfter.sub(lenderBalanceBefore)).to.equal(0);
         });
+
         it("Scenario: numInstallments: 4, durationSecs: 36000. Borrower repays minimum. Lender tries to claim in same installment, should revert", async () => {
             const context = await loadFixture(fixture);
             const { repaymentController, loanCore, mockERC20, vaultFactory, borrower, lender, blockchainTime } =
@@ -2048,6 +2055,7 @@ describe("Installments", () => {
             expect(borrowerBalanceAfter.sub(borrowerBalanceBefore)).to.equal(0);
             expect(lenderBalanceAfter.sub(lenderBalanceBefore)).to.equal(0);
         });
+
         it("Scenario: numInstallments: 4, durationSecs: 36000. Borrower repays minimum. Lender tries to claim in second installment, should revert", async () => {
             const context = await loadFixture(fixture);
             const { repaymentController, loanCore, mockERC20, vaultFactory, borrower, lender, blockchainTime } =
@@ -2083,6 +2091,7 @@ describe("Installments", () => {
             expect(borrowerBalanceAfter.sub(borrowerBalanceBefore)).to.equal(0);
             expect(lenderBalanceAfter.sub(lenderBalanceBefore)).to.equal(0);
         });
+
         it("Scenario: numInstallments: 4, durationSecs: 36000. Borrower repays minimum. Lender tries to claim various times in loan duration.", async () => {
             const context = await loadFixture(fixture);
             const { repaymentController, loanCore, mockERC20, vaultFactory, borrower, lender, blockchainTime } =
@@ -2134,6 +2143,7 @@ describe("Installments", () => {
             expect(borrowerBalanceAfter.sub(borrowerBalanceBefore)).to.equal(0);
             expect(lenderBalanceAfter.sub(lenderBalanceBefore)).to.equal(1);
         });
+
         it("Scenario: numInstallments: 10, durationSecs: 36000. Borrower repays minimum. Lender tries to claim various times in loan duration.", async () => {
             const context = await loadFixture(fixture);
             const { repaymentController, loanCore, mockERC20, vaultFactory, borrower, lender, blockchainTime } =
@@ -2185,6 +2195,7 @@ describe("Installments", () => {
             expect(borrowerBalanceAfter.sub(borrowerBalanceBefore)).to.equal(0);
             expect(lenderBalanceAfter.sub(lenderBalanceBefore)).to.equal(1);
         });
+
         it("Scenario: numInstallments: 24, durationSecs: 2y. Borrower repays minimum. Lender tries to claim various times in loan duration.", async () => {
             const context = await loadFixture(fixture);
             const { repaymentController, loanCore, mockERC20, vaultFactory, borrower, lender, blockchainTime } =
@@ -2238,6 +2249,7 @@ describe("Installments", () => {
             expect(borrowerBalanceAfter.sub(borrowerBalanceBefore)).to.equal(0);
             expect(lenderBalanceAfter.sub(lenderBalanceBefore)).to.equal(1);
         });
+
         it("Scenario: numInstallments: 4, durationSecs: 1 month. Borrower repays min 4 times and leaves. Lender tries to claim various times in duration.", async () => {
             const context = await loadFixture(fixture);
             const { repaymentController, loanCore, mockERC20, vaultFactory, borrower, lender, blockchainTime } =
@@ -2291,6 +2303,7 @@ describe("Installments", () => {
             expect(borrowerBalanceAfter.sub(borrowerBalanceBefore)).to.equal(0);
             expect(lenderBalanceAfter.sub(lenderBalanceBefore)).to.equal(1);
         });
+
         it("Scenario: numInstallments: 3, durationSecs: 1 month. Borrower repays min 3 times and leaves. Lender tries to claim various times induration.", async () => {
             const context = await loadFixture(fixture);
             const { repaymentController, loanCore, mockERC20, vaultFactory, borrower, lender, blockchainTime } =
@@ -2337,6 +2350,7 @@ describe("Installments", () => {
             expect(borrowerBalanceAfter.sub(borrowerBalanceBefore)).to.equal(0);
             expect(lenderBalanceAfter.sub(lenderBalanceBefore)).to.equal(1);
         });
+
         it("Scenario: numInstallments: 2, durationSecs: 1 week. Borrower repays min 2 times and leaves. Lender tries to claim various times in duration.", async () => {
             const context = await loadFixture(fixture);
             const { repaymentController, loanCore, mockERC20, vaultFactory, borrower, lender, blockchainTime } =

--- a/test/Installments.ts
+++ b/test/Installments.ts
@@ -2238,5 +2238,58 @@ describe("Installments", () => {
             expect(borrowerBalanceAfter.sub(borrowerBalanceBefore)).to.equal(0);
             expect(lenderBalanceAfter.sub(lenderBalanceBefore)).to.equal(1);
         });
+        it("Scenario: numInstallments: 4, durationSecs: 1 month. Borrower repays minimum 3 times and leaves. Lender tries to claim various times in loan duration.", async () => {
+            const context = await loadFixture(fixture);
+            const { repaymentController, loanCore, mockERC20, vaultFactory, borrower, lender, blockchainTime } =
+                context;
+            const { loanId } = await initializeInstallmentLoan(
+                context,
+                mockERC20.address,
+                BigNumber.from(31536000 / 12), // durationSecs
+                hre.ethers.utils.parseEther("100"), // principal
+                hre.ethers.utils.parseEther("1000"), // interest
+                4, // numInstallments
+                1754884800, // deadline
+            );
+            const borrowerBalanceBefore = await vaultFactory.balanceOf(await borrower.getAddress());
+            const lenderBalanceBefore = await vaultFactory.balanceOf(await lender.getAddress());
+
+            //increase time slightly
+            await blockchainTime.increaseTime(100);
+            // borrower repays minimum
+            await mockERC20.connect(borrower).approve(repaymentController.address, ethers.utils.parseEther("2.5"));
+            await expect(repaymentController.connect(borrower).repayPartMinimum(loanId)).to.emit(mockERC20, "Transfer");
+            //(second installment period)
+            await blockchainTime.increaseTime((31536000 / 12) / 4);
+            // borrower repays minimum
+            await mockERC20.connect(borrower).approve(repaymentController.address, ethers.utils.parseEther("2.5"));
+            await expect(repaymentController.connect(borrower).repayPartMinimum(loanId)).to.emit(mockERC20, "Transfer");
+            // have lender call claim on the collateral
+            await expect(repaymentController.connect(lender).claim(loanId)).to.be.revertedWith("LC_LoanNotDefaulted");
+            // (third installment period)
+            await blockchainTime.increaseTime((31536000 / 12) / 4);
+            // borrower repays minimum
+            await mockERC20.connect(borrower).approve(repaymentController.address, ethers.utils.parseEther("2.5"));
+            await expect(repaymentController.connect(borrower).repayPartMinimum(loanId)).to.emit(mockERC20, "Transfer");
+            // have lender call claim on the collateral
+            await expect(repaymentController.connect(lender).claim(loanId)).to.be.revertedWith("LC_LoanNotDefaulted");
+            // (forth installment period)
+            await blockchainTime.increaseTime((31536000 / 12) / 4);
+            // borrower repays minimum
+            await mockERC20.connect(borrower).approve(repaymentController.address, ethers.utils.parseEther("2.5"));
+            await expect(repaymentController.connect(borrower).repayPartMinimum(loanId)).to.emit(mockERC20, "Transfer");
+            // have lender call claim on the collateral
+            await expect(repaymentController.connect(lender).claim(loanId)).to.be.revertedWith("LC_LoanNotDefaulted");
+            // (fifth installment period)
+            await blockchainTime.increaseTime(((31536000 / 12) / 4) - 100);
+            // have lender call claim on the collateral --> claimable
+            await expect(repaymentController.connect(lender).claim(loanId)).to.emit(loanCore, "LoanClaimed");
+
+            // check balances
+            const borrowerBalanceAfter = await vaultFactory.balanceOf(await borrower.getAddress());
+            const lenderBalanceAfter = await vaultFactory.balanceOf(await lender.getAddress());
+            expect(borrowerBalanceAfter.sub(borrowerBalanceBefore)).to.equal(0);
+            expect(lenderBalanceAfter.sub(lenderBalanceBefore)).to.equal(1);
+        });
     });
 });


### PR DESCRIPTION
Per Roku comments: "In the function` _verifyDefaultedLoan`, if it's a loan with installments, it only checks if the missed installments is < 40% of total number of installments. This leads to scenarios when the borrower still keeps paying the 'minimum' interest, it will make the loan "non defaultable" and the lender would have no way to get his principal back even after the duration."

Fix: Logic was added to the `claim` function in LoanCore. This function now will return the loanId as Defaulted if the function call is made after the `dueDate`. The `dueDate` is `startDate + durationSecs`. This behavior mimics the default behavior for legacy loan types. 

Tests: 3 tests were added to the end of Installments.ts for better introspection of short term loans with minimal installments. The purpose of these tests are to prove out the logic described above.