### PR TITLE
fix(fix-setup-roles): refactor per code review

### DIFF
--- a/.deployments/rinkeby/rinkeby-1655322662652000.json
+++ b/.deployments/rinkeby/rinkeby-1655322662652000.json
@@ -1,0 +1,55 @@
+{
+  "CallWhitelist": {
+    "contractAddress": "0xAacafFA6c0Be30Ca42d6c792A3876CAa19F3e90e",
+    "contractImplementationAddress": "",
+    "constructorArgs": []
+  },
+  "AssetVault": {
+    "contractAddress": "0x51B3359Fb071821cf75c96215B9aACef0e57833B",
+    "contractImplementationAddress": "",
+    "constructorArgs": []
+  },
+  "VaultFactory": {
+    "contractAddress": "0x590F8679e27AcFa15B6253810E2791081fb1b3EE",
+    "contractImplementationAddress": "0xC804d7Cf57162Cb6053e4D8Fc13b4f258477b40f",
+    "constructorArgs": []
+  },
+  "FeeController": {
+    "contractAddress": "0x5884f8F23F977B1220A9b618d95bCb8c9c7Ff211",
+    "contractImplementationAddress": "",
+    "constructorArgs": []
+  },
+  "BorrowerNote": {
+    "contractAddress": "0xDD86baCAA5F60cfCf2331C98aa02f42d3ec7eA23",
+    "constructorArgs": [
+      "Arcade.xyz BorrowerNote",
+      "aBN"
+    ]
+  },
+  "LenderNote": {
+    "contractAddress": "0xe649a32a84E3E8d044a533645008459Bf2C82CD3",
+    "constructorArgs": [
+      "Arcade.xyz LenderNote",
+      "aLN"
+    ]
+  },
+  "LoanCore": {
+    "contractAddress": "0xe8Ebc13D3f1e9ab1ce7A9711C36a2460805D7443",
+    "contractImplementationAddress": "0xB6Bd97421564030a5018DD6d0Fc4a362b8228B82",
+    "constructorArgs": []
+  },
+  "RepaymentController": {
+    "contractAddress": "0xD0Ad4AEcD2C5d98CF2AA757bfE36d6afD6254D91",
+    "contractImplementationAddress": "",
+    "constructorArgs": [
+      "0xe8Ebc13D3f1e9ab1ce7A9711C36a2460805D7443",
+      "0xDD86baCAA5F60cfCf2331C98aa02f42d3ec7eA23",
+      "0xe649a32a84E3E8d044a533645008459Bf2C82CD3"
+    ]
+  },
+  "OriginationController": {
+    "contractAddress": "0xce03CafBB6f6571398aE14A9ef914abe6D66A01b",
+    "contractImplementationAddress": "0xa4F802ff09f5370B6601D626a65A924824dADF28",
+    "constructorArgs": []
+  }
+}

--- a/.openzeppelin/rinkeby.json
+++ b/.openzeppelin/rinkeby.json
@@ -2,300 +2,40 @@
   "manifestVersion": "3.2",
   "proxies": [
     {
-      "address": "0x097586FE2775d9F0aB5baE01900db8410de0689c",
-      "txHash": "0x8b9bec7e6f27b2af5e06c21d22318c1789e3d29ece062d8d4ee57a366dbe90f6",
+      "address": "0x6c9Dce911cE796F78a0f3B02c107C4919d59f460",
+      "txHash": "0xee6754820a1f24328e9319a29cf5febd7926ffa022ab2afb944a3ff86cc4e75c",
       "kind": "uups"
     },
     {
-      "address": "0x20DeFBB7A64f31D959bCEa68A68F22Ab5399A2Eb",
-      "txHash": "0xfe67145d4f7584cf287a9bc3eaf173e62c605dd1955c60f869d82a9264a8e9e1",
+      "address": "0xFF9195f0713af19592e1587278cF47505081F18f",
+      "txHash": "0xd21b4501492d569d99b20cfb91f5232080892a77f1a6a2f36f1d6eb4a01b81d9",
       "kind": "uups"
     },
     {
-      "address": "0x01900B2F79a9FCf07CC528D2D91b613e5F9025EF",
-      "txHash": "0x517898f6d5147a2dc62b7a7584b345fc98e95598b9b9435bf3229c8724374f50",
+      "address": "0xb8d8F8Fff7bEF6F89EC1c430E48162f8A0213732",
+      "txHash": "0x3163cf568520e36f6e283f57dda1d028605a795ebdce22d726bef2f72b72374a",
       "kind": "uups"
     },
     {
-      "address": "0xBF05e0d47cDF6BdcC351f2F72C49cd38a1A815dB",
-      "txHash": "0xc2c41f52bc55e99530cf660affd022085555eecc752f82b488e36671bd1e0d67",
+      "address": "0x590F8679e27AcFa15B6253810E2791081fb1b3EE",
+      "txHash": "0xa811139399cdb196121db9dc5bfaa9542934e1e8a8d510fd404612faaaaafd78",
       "kind": "uups"
     },
     {
-      "address": "0x4c6327629d8aEb1BEa2Fd0Aafee1867a3ADe69Df",
-      "txHash": "0x0dc341e7a864bc552bdf052de87597979fbfa7717194d36dc188a8af2ce5d781",
+      "address": "0xe8Ebc13D3f1e9ab1ce7A9711C36a2460805D7443",
+      "txHash": "0x97b51dfc09b1cb002050a0ea6410705a631c31318708df909c769a5039d12bec",
       "kind": "uups"
     },
     {
-      "address": "0xC484Af467a45A8A5A1db7105Fa08cb5CE373f310",
-      "txHash": "0x416fd135da1d911ba77118f25efbe2853246224b9e93fd92d7ca20c58de57c67",
-      "kind": "uups"
-    },
-    {
-      "address": "0xeDeD1436c45b6C2e55D1d09F07a725fd38C37077",
-      "txHash": "0x3353ae68793ddfa9e715b843ab297a65a4d7c9f54c9b2fe052a85f2bb482d124",
-      "kind": "uups"
-    },
-    {
-      "address": "0x14c61bCE30882Ef9658C43891adB30C14e367328",
-      "txHash": "0x3449655e816da5d23294931de5da508bd75e3ebde662de4d1a58c91d437dc00c",
-      "kind": "uups"
-    },
-    {
-      "address": "0xE74037A92062F6924af654EAB48da479cbda8835",
-      "txHash": "0xbe0969e98e54168a3a8289897a2498237526ea25d710c94d223755c2e17e4111",
-      "kind": "uups"
-    },
-    {
-      "address": "0x019819674a736b560111bd7656D11893742c8aA0",
-      "txHash": "0xbd2088a01199429ee40f99bb8fe40f326d952253ed6d71350c52af9fd59b1140",
-      "kind": "uups"
-    },
-    {
-      "address": "0x09DD267f546Ac8325C63021dF11d55A5a2cE78c7",
-      "txHash": "0x45117f065808cbef50fea89ebe0c177f0a84f91bb5ff3f15aab95642ee53e409",
-      "kind": "uups"
-    },
-    {
-      "address": "0x113BBcfbdDC0678de02220bd170a32A1d7c2f342",
-      "txHash": "0x790cd30ed06cc332819a220863a3330fbb8a2262ca8ece6dc3498b375ef39fcb",
-      "kind": "uups"
-    },
-    {
-      "address": "0xe5B514E21D8382daAc407520f8866a8F1E05f3eF",
-      "txHash": "0x4db7433f0d8755a6d56f65fae725bb34b18343f4957114cfc0fe6013469e0e03",
-      "kind": "uups"
-    },
-    {
-      "address": "0xd11ce361f6D0cdF7e0f52122cCA5fAEBD095b0c6",
-      "txHash": "0xb24d37ca58c2ce50e4fe66b0322bb41d4889b92bb84790e224182690e94be2be",
-      "kind": "uups"
-    },
-    {
-      "address": "0x458ba7d3BEF16cB52e39fc4ab3BDDD69AbCfE227",
-      "txHash": "0x92423195e3d1b74e156e080f13a07e003b20795d2b8f02411e970d9732e91d5d",
-      "kind": "uups"
-    },
-    {
-      "address": "0xF5Ed3c53439bab1C1760a91D28E3062ec091B3A8",
-      "txHash": "0xbeb1829f0a1545df9f41d0601232d9229970c3dae4433372accbc67948c26d0a",
-      "kind": "uups"
-    },
-    {
-      "address": "0x761163b497ebd35ABA78978203D767b74D6Bc067",
-      "txHash": "0xac019e8eefa8043fbe7f479bd4d81bb12b2fa04771390ffcc9295b8783a555da",
-      "kind": "uups"
-    },
-    {
-      "address": "0x5F1795924Dd7454C48EF039984a2879B97eE7632",
-      "txHash": "0x62fee35fe5cf4f64c38710a3016254532de23cdb300eb81472c2191acb29a23d",
-      "kind": "uups"
-    },
-    {
-      "address": "0x61BC03482E87dA533BbE222062B49072c60f70C7",
-      "txHash": "0x314cc1f079f913cc55a6efee496d09e95f05bc35f3988b76d1eca88da156c0fb",
-      "kind": "uups"
-    },
-    {
-      "address": "0x361502A22F367289709F074859257B7e75e88278",
-      "txHash": "0xd0558d7867bd5e392d9dad04229370880dea75ec72308e20c5321151f3fb74ab",
-      "kind": "uups"
-    },
-    {
-      "address": "0x5c17481284D083D03330C59a67a3334c34c87508",
-      "txHash": "0xacccba818304b8b0f3756b02305ff058f6d0401f6f0ced752de62b8f18b711dc",
-      "kind": "uups"
-    },
-    {
-      "address": "0x35F9D2B91F4B138039956164f4134887B387BFA1",
-      "txHash": "0xe102734f6250f89f6d5e8500714e22c0eb12cfa07d73f489dc22b4b203ff5379",
-      "kind": "uups"
-    },
-    {
-      "address": "0xf203337a217e5bc14aF7034e3419bD67675C6Ec9",
-      "txHash": "0xb5571b0e0fb650c484433aa0a66f7ea7ef86be03fe14651bc64465b07cde1b8b",
-      "kind": "uups"
-    },
-    {
-      "address": "0xaFD14896A53f42a53f82ADC84b419E88AF7989C3",
-      "txHash": "0x3a9f095dfcf5649d8dfbe27c45e5373a3b3dbe8e5cf493de79b000dba242fc10",
-      "kind": "uups"
-    },
-    {
-      "address": "0xFF9ca36A41fBBf63a8dAa1A1941182551d253469",
-      "txHash": "0x75608d33e717fa488370ffbddc057e19f462cee81dff700e8443795a85ba845f",
-      "kind": "uups"
-    },
-    {
-      "address": "0xc490415De27F6D7Ff7FcE19884A21613144795a8",
-      "txHash": "0x41df0374a07775385fc8ec3a5a6a6971211fcb8d5103924795ba0afb5b83d9a7",
-      "kind": "uups"
-    },
-    {
-      "address": "0xe3832ba3c3AFb4B9044ec2Ce44547DD44da0Fc46",
-      "txHash": "0xeed06473e173b1b63c62d290fcafeefff6f60f0ab1efec740294c0ed30a6d942",
-      "kind": "uups"
-    },
-    {
-      "address": "0xf7db166A72b70B388a3C44912890426b82AfD5D7",
-      "txHash": "0x57a718a24cbccf4ed0fc5ed42c7170ca8a596c56abfa5b9af508a98904b218fb",
-      "kind": "uups"
-    },
-    {
-      "address": "0x1Db11B52e58FF69151240c1155d26070aEB95378",
-      "txHash": "0x4ee10a8895bb474bd515a2b46229111bda03393825a8a248a18d1f04a3a18559",
-      "kind": "uups"
-    },
-    {
-      "address": "0x20d513079c9610e227f702fAc8b8Fd58c1ecc6aa",
-      "txHash": "0x9528d1a7ec5cec961561bc3cba712fb84ed6e2d99bbdd9342b0e15a13020422b",
-      "kind": "uups"
-    },
-    {
-      "address": "0x3bA84E37fb083bCDDe2C158e8BEb0BbcC001fCAb",
-      "txHash": "0x7e4fca1a86eed889b26bcfa47f6ffa1167584a6e1833953c3f910ee56cce9f7f",
-      "kind": "uups"
-    },
-    {
-      "address": "0x8450b73df95a07437f950dfafB0a60AAaD31499a",
-      "txHash": "0xdf53e6d9f92ee1479a5458352716bb2721323f4abb27d632bc5a49abebc2ac9a",
-      "kind": "uups"
-    },
-    {
-      "address": "0xfDeD554CF4553eA4b850342758d04aDD1981e35C",
-      "txHash": "0x84d8fdca9806387ad84ed08a38c6e363a0724e8fdcb648f690c60e094739f97a",
-      "kind": "uups"
-    },
-    {
-      "address": "0x53D19679956eD0f2dD0Ae2F4f047a72951d7Bd37",
-      "txHash": "0x0df75d863295abe838c9d1d74c1d9a0fa04bba696ea5391c85a702a698d9d3dd",
-      "kind": "uups"
-    },
-    {
-      "address": "0x4033F75c5b22ABd4BeDB22A663Eaa5E4a83B4302",
-      "txHash": "0xdcae92e914ddcefb528eeb029e53bff5cd4c8851d8bc4f827618b3913c26c2e3",
-      "kind": "uups"
-    },
-    {
-      "address": "0x64400724C1F4Da05620427F6a70a7FeE1118DC26",
-      "txHash": "0x4aef07462d0f6bad46a4fdb9809b19b90be7a9d296a518509faba0267575356a",
-      "kind": "uups"
-    },
-    {
-      "address": "0xE7C1dB310017e1C1F237f48D23Bc181594c884dF",
-      "txHash": "0x3384311551517150d909b44a4ec592e2652fef34ebe1d506e3128de1a785a42e",
-      "kind": "uups"
-    },
-    {
-      "address": "0x199bC30655DF97ff55d8241a8a6a9a7bD5DE00d4",
-      "txHash": "0x665b69c17364f48249c89bc89df61bf73b348b11c2d31de2e330d14aacf64990",
-      "kind": "uups"
-    },
-    {
-      "address": "0xF39Ce24cf850f1bae122BBaCce0adB853c5a7Dc9",
-      "txHash": "0x39ad672619186deba590e132911b1553e60ce0f9d7c0c10a0495b19fac4893e3",
-      "kind": "uups"
-    },
-    {
-      "address": "0xee319a4E54255F770b19a1BCb15D218A29FA8750",
-      "txHash": "0x0172c2b1e895e653db9c4bea70815e225c6c97e2de6834f5f23fe36517ea4c44",
-      "kind": "uups"
-    },
-    {
-      "address": "0xC37C60665b2C522C747EEC0a63672Fbc31ADADc7",
-      "txHash": "0x97aeee8747098bb16102c68495927427c5cb8f20e2eb2363ea29c3d578a2bb33",
-      "kind": "uups"
-    },
-    {
-      "address": "0xE1C0eb596FFA78eF229a818F240f5a51ad736f5E",
-      "txHash": "0x5bcc8945dcbb0ada74075fefec70c0421f5455ba87b5c7c18a32baf46514b3c5",
-      "kind": "uups"
-    },
-    {
-      "address": "0x29B8e5D20af891C876662426e02BB0201eBC7969",
-      "txHash": "0x40e1e04ee318282a0cb7b760390a87841bf9a1c7252794d3274fa0d40b10512c",
-      "kind": "uups"
-    },
-    {
-      "address": "0x5b569EeBeB5DE43D7a68a02E17a50Df9114d69E9",
-      "txHash": "0x9a3f3ea210114189ad053836585ddceecfa4ac36e484e9bbd569b472cf159730",
-      "kind": "uups"
-    },
-    {
-      "address": "0x0169647dBE414D024dE9B21eFdf6928569Df9e7e",
-      "txHash": "0x2b45a22ce5690dfa7e85813cd3fbe6655b57a559abf339cb54385ea466e43210",
-      "kind": "uups"
-    },
-    {
-      "address": "0xB029C171eBe5FfdAC7cEa6804a5EbA2Aa80D873A",
-      "txHash": "0x57427676e23340cef23b90d2c610a50f9004b2986e311ff92120f679155d12cb",
-      "kind": "uups"
-    },
-    {
-      "address": "0x82376dA76043796dbdDc915e424A56e547e91D7d",
-      "txHash": "0x8f05490d2bd91fe7ea0e9155568c98101b532ef66d06c7a0d93b603e9e421cfb",
-      "kind": "uups"
-    },
-    {
-      "address": "0x95EA08e049f5933FD3A56FE527296c4B016f809D",
-      "txHash": "0x2b4ab10b98635ed8e43dc6f7c855042b9c1694f6a3103104c415d28e87b82534",
-      "kind": "uups"
-    },
-    {
-      "address": "0x9147389dCB3C917832613991b29e339e320655A8",
-      "txHash": "0x1356fa839277497c135e01d13ed27fbeb6e5ebd8ea29759048a656df46ca4b86",
-      "kind": "uups"
-    },
-    {
-      "address": "0xEe9e1289fAd6bAe1b99b3dce523097A682B9F4bF",
-      "txHash": "0x7f2742fc21ded11f601671cf488714810d6cbd075d45e57bd20d9424c3da2c60",
-      "kind": "uups"
-    },
-    {
-      "address": "0xb7aAD9c87f0D1AFf033b6c9ef94b12F16DcAF648",
-      "txHash": "0x53bb71f1452165d06d4338eaf2d3411433f7382a69210661f5fad3223a431e05",
-      "kind": "uups"
-    },
-    {
-      "address": "0xe44fC3D8FeDb881B9a1E8fE63Cf0CCdA1A8280FE",
-      "txHash": "0x4d9411951d42a33df4639f498b85797fe41d066f30d4c0e33932bb1b861f149c",
-      "kind": "uups"
-    },
-    {
-      "address": "0xe9479496E0BdE4314A889f70fd3EbD57d8f429dD",
-      "txHash": "0x484efbd934afa74acb1dbac1bc4ed62f682dfad63cec818be3458f25c020983d",
-      "kind": "uups"
-    },
-    {
-      "address": "0xc9fcf73d82ef5BEE17256de35742aC787F6b3504",
-      "txHash": "0xe85e5d820aabd5428abe77d0f25a8b75478279cd8af9afd5b8aef6c80d87b054",
-      "kind": "uups"
-    },
-    {
-      "address": "0x7D0fcAa568C0b06D4935CcA962dF0FEf384A36B4",
-      "txHash": "0x77f2b1d6cfb3af41368c1303de2469526937e1a4aa2053d52062efeceb9dc6e0",
-      "kind": "uups"
-    },
-    {
-      "address": "0xBeddD74f484a6646C0d47c8B8F121D7699ac280D",
-      "txHash": "0x7c898accc1bca053aa2b7e2814e1db93e1bfaf64701bad8b3c6b19e7aea4a892",
-      "kind": "uups"
-    },
-    {
-      "address": "0xeA6d38B16ac3Db215592782FA7b2466F5531e532",
-      "txHash": "0xf2d92bd81cffa1330c551952c2870ca33126de3c0b2d31bea799a29434ad3fea",
-      "kind": "uups"
-    },
-    {
-      "address": "0x975a0B2117EC98559F1ADf85C0058Ac5E5B1ec71",
-      "txHash": "0xc895640d3ed88c4fb377c53e73f01c83e6fc6bcba49802ee10546ea74b3f11e8",
+      "address": "0xce03CafBB6f6571398aE14A9ef914abe6D66A01b",
+      "txHash": "0x6a486dc205904f722d9c2aa7772e3f06609868472bcfd8c966c8dbb8a698a5e6",
       "kind": "uups"
     }
   ],
   "impls": {
     "52674a9014b88a94e0fa72b23856de2f49819428033756f1e81cbc826d629444": {
-      "address": "0xf48bbCC7f8b62f257a06cE6844E16b6C2761Ceec",
-      "txHash": "0x5e070a01c33fdf1611ca87eb4c73d2cfbd545e6bbbdee60cf42e54a4428fba38",
+      "address": "0xC804d7Cf57162Cb6053e4D8Fc13b4f258477b40f",
+      "txHash": "0xb7b6e6c1a3e5eb9ed4caab7f180c3c4c5f702f95328951b697c16545760ff3a6",
       "layout": {
         "storage": [
           {
@@ -613,9 +353,9 @@
         }
       }
     },
-    "d9f11f10b4559352ce2399a4d612f881a956026257bd23ca64eadbc459c5b0a0": {
-      "address": "0x1f39FB1514c2cb392ef62B453F17a0afd3789796",
-      "txHash": "0x1103e01c7a7725537f0c21e1e1a8f8899cca54d605bc382d22929e2739483f52",
+    "d4b4f81e1bad650eeb05f950b87905604a0a2d72da746d7c38096cf4babb5d2b": {
+      "address": "0xB6Bd97421564030a5018DD6d0Fc4a362b8228B82",
+      "txHash": "0xae805dd97fdb5d7f8eb34ba2e52d4bb3b4149604936e6e6af31e08c8fa90cc8e",
       "layout": {
         "storage": [
           {
@@ -702,25 +442,25 @@
             "label": "borrowerNote",
             "offset": 0,
             "slot": "301",
-            "type": "t_contract(IPromissoryNote)19306",
+            "type": "t_contract(IPromissoryNote)19309",
             "contract": "LoanCore",
-            "src": "contracts/LoanCore.sol:74"
+            "src": "contracts/LoanCore.sol:68"
           },
           {
             "label": "lenderNote",
             "offset": 0,
             "slot": "302",
-            "type": "t_contract(IPromissoryNote)19306",
+            "type": "t_contract(IPromissoryNote)19309",
             "contract": "LoanCore",
-            "src": "contracts/LoanCore.sol:75"
+            "src": "contracts/LoanCore.sol:69"
           },
           {
             "label": "feeController",
             "offset": 0,
             "slot": "303",
-            "type": "t_contract(IFeeController)18684",
+            "type": "t_contract(IFeeController)18687",
             "contract": "LoanCore",
-            "src": "contracts/LoanCore.sol:76"
+            "src": "contracts/LoanCore.sol:70"
           },
           {
             "label": "loanIdTracker",
@@ -728,15 +468,15 @@
             "slot": "304",
             "type": "t_struct(Counter)4088_storage",
             "contract": "LoanCore",
-            "src": "contracts/LoanCore.sol:80"
+            "src": "contracts/LoanCore.sol:74"
           },
           {
             "label": "loans",
             "offset": 0,
             "slot": "305",
-            "type": "t_mapping(t_uint256,t_struct(LoanData)19487_storage)",
+            "type": "t_mapping(t_uint256,t_struct(LoanData)19490_storage)",
             "contract": "LoanCore",
-            "src": "contracts/LoanCore.sol:81"
+            "src": "contracts/LoanCore.sol:75"
           },
           {
             "label": "collateralInUse",
@@ -744,7 +484,7 @@
             "slot": "306",
             "type": "t_mapping(t_bytes32,t_bool)",
             "contract": "LoanCore",
-            "src": "contracts/LoanCore.sol:83"
+            "src": "contracts/LoanCore.sol:77"
           },
           {
             "label": "usedNonces",
@@ -752,7 +492,7 @@
             "slot": "307",
             "type": "t_mapping(t_address,t_mapping(t_uint160,t_bool))",
             "contract": "LoanCore",
-            "src": "contracts/LoanCore.sol:84"
+            "src": "contracts/LoanCore.sol:78"
           }
         ],
         "types": {
@@ -776,15 +516,15 @@
             "label": "bytes32",
             "numberOfBytes": "32"
           },
-          "t_contract(IFeeController)18684": {
+          "t_contract(IFeeController)18687": {
             "label": "contract IFeeController",
             "numberOfBytes": "20"
           },
-          "t_contract(IPromissoryNote)19306": {
+          "t_contract(IPromissoryNote)19309": {
             "label": "contract IPromissoryNote",
             "numberOfBytes": "20"
           },
-          "t_enum(LoanState)19419": {
+          "t_enum(LoanState)19422": {
             "label": "enum LoanLibrary.LoanState",
             "members": [
               "DUMMY_DO_NOT_USE",
@@ -814,7 +554,7 @@
             "label": "mapping(uint160 => bool)",
             "numberOfBytes": "32"
           },
-          "t_mapping(t_uint256,t_struct(LoanData)19487_storage)": {
+          "t_mapping(t_uint256,t_struct(LoanData)19490_storage)": {
             "label": "mapping(uint256 => struct LoanLibrary.LoanData)",
             "numberOfBytes": "32"
           },
@@ -830,12 +570,12 @@
             ],
             "numberOfBytes": "32"
           },
-          "t_struct(LoanData)19487_storage": {
+          "t_struct(LoanData)19490_storage": {
             "label": "struct LoanLibrary.LoanData",
             "members": [
               {
                 "label": "state",
-                "type": "t_enum(LoanState)19419",
+                "type": "t_enum(LoanState)19422",
                 "offset": 0,
                 "slot": "0"
               },
@@ -853,7 +593,7 @@
               },
               {
                 "label": "terms",
-                "type": "t_struct(LoanTerms)19441_storage",
+                "type": "t_struct(LoanTerms)19444_storage",
                 "offset": 0,
                 "slot": "1"
               },
@@ -878,7 +618,7 @@
             ],
             "numberOfBytes": "288"
           },
-          "t_struct(LoanTerms)19441_storage": {
+          "t_struct(LoanTerms)19444_storage": {
             "label": "struct LoanLibrary.LoanTerms",
             "members": [
               {
@@ -967,840 +707,169 @@
             "numberOfBytes": "4"
           }
         }
-    ],
-    "impls": {
-        "52674a9014b88a94e0fa72b23856de2f49819428033756f1e81cbc826d629444": {
-            "address": "0xd7D00aBC891e2A9FF77C4BA04378AEc9fA09c1AE",
-            "txHash": "0xc9d59bcb905a9e1880abfb1113dd98748f773262b31d376b6a0fac8559f3d5e2",
-            "layout": {
-                "storage": [
-                    {
-                        "label": "_initialized",
-                        "offset": 0,
-                        "slot": "0",
-                        "type": "t_bool",
-                        "contract": "Initializable",
-                        "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:39"
-                    },
-                    {
-                        "label": "_initializing",
-                        "offset": 1,
-                        "slot": "0",
-                        "type": "t_bool",
-                        "contract": "Initializable",
-                        "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:44"
-                    },
-                    {
-                        "label": "__gap",
-                        "offset": 0,
-                        "slot": "1",
-                        "type": "t_array(t_uint256)50_storage",
-                        "contract": "ContextUpgradeable",
-                        "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:36"
-                    },
-                    {
-                        "label": "__gap",
-                        "offset": 0,
-                        "slot": "51",
-                        "type": "t_array(t_uint256)50_storage",
-                        "contract": "ERC165Upgradeable",
-                        "src": "@openzeppelin/contracts-upgradeable/utils/introspection/ERC165Upgradeable.sol:41"
-                    },
-                    {
-                        "label": "_name",
-                        "offset": 0,
-                        "slot": "101",
-                        "type": "t_string_storage",
-                        "contract": "ERC721Upgradeable",
-                        "src": "@openzeppelin/contracts-upgradeable/token/ERC721/ERC721Upgradeable.sol:25"
-                    },
-                    {
-                        "label": "_symbol",
-                        "offset": 0,
-                        "slot": "102",
-                        "type": "t_string_storage",
-                        "contract": "ERC721Upgradeable",
-                        "src": "@openzeppelin/contracts-upgradeable/token/ERC721/ERC721Upgradeable.sol:28"
-                    },
-                    {
-                        "label": "_owners",
-                        "offset": 0,
-                        "slot": "103",
-                        "type": "t_mapping(t_uint256,t_address)",
-                        "contract": "ERC721Upgradeable",
-                        "src": "@openzeppelin/contracts-upgradeable/token/ERC721/ERC721Upgradeable.sol:31"
-                    },
-                    {
-                        "label": "_balances",
-                        "offset": 0,
-                        "slot": "104",
-                        "type": "t_mapping(t_address,t_uint256)",
-                        "contract": "ERC721Upgradeable",
-                        "src": "@openzeppelin/contracts-upgradeable/token/ERC721/ERC721Upgradeable.sol:34"
-                    },
-                    {
-                        "label": "_tokenApprovals",
-                        "offset": 0,
-                        "slot": "105",
-                        "type": "t_mapping(t_uint256,t_address)",
-                        "contract": "ERC721Upgradeable",
-                        "src": "@openzeppelin/contracts-upgradeable/token/ERC721/ERC721Upgradeable.sol:37"
-                    },
-                    {
-                        "label": "_operatorApprovals",
-                        "offset": 0,
-                        "slot": "106",
-                        "type": "t_mapping(t_address,t_mapping(t_address,t_bool))",
-                        "contract": "ERC721Upgradeable",
-                        "src": "@openzeppelin/contracts-upgradeable/token/ERC721/ERC721Upgradeable.sol:40"
-                    },
-                    {
-                        "label": "__gap",
-                        "offset": 0,
-                        "slot": "107",
-                        "type": "t_array(t_uint256)44_storage",
-                        "contract": "ERC721Upgradeable",
-                        "src": "@openzeppelin/contracts-upgradeable/token/ERC721/ERC721Upgradeable.sol:458"
-                    },
-                    {
-                        "label": "_ownedTokens",
-                        "offset": 0,
-                        "slot": "151",
-                        "type": "t_mapping(t_address,t_mapping(t_uint256,t_uint256))",
-                        "contract": "ERC721EnumerableUpgradeable",
-                        "src": "@openzeppelin/contracts-upgradeable/token/ERC721/extensions/ERC721EnumerableUpgradeable.sol:22"
-                    },
-                    {
-                        "label": "_ownedTokensIndex",
-                        "offset": 0,
-                        "slot": "152",
-                        "type": "t_mapping(t_uint256,t_uint256)",
-                        "contract": "ERC721EnumerableUpgradeable",
-                        "src": "@openzeppelin/contracts-upgradeable/token/ERC721/extensions/ERC721EnumerableUpgradeable.sol:25"
-                    },
-                    {
-                        "label": "_allTokens",
-                        "offset": 0,
-                        "slot": "153",
-                        "type": "t_array(t_uint256)dyn_storage",
-                        "contract": "ERC721EnumerableUpgradeable",
-                        "src": "@openzeppelin/contracts-upgradeable/token/ERC721/extensions/ERC721EnumerableUpgradeable.sol:28"
-                    },
-                    {
-                        "label": "_allTokensIndex",
-                        "offset": 0,
-                        "slot": "154",
-                        "type": "t_mapping(t_uint256,t_uint256)",
-                        "contract": "ERC721EnumerableUpgradeable",
-                        "src": "@openzeppelin/contracts-upgradeable/token/ERC721/extensions/ERC721EnumerableUpgradeable.sol:31"
-                    },
-                    {
-                        "label": "__gap",
-                        "offset": 0,
-                        "slot": "155",
-                        "type": "t_array(t_uint256)46_storage",
-                        "contract": "ERC721EnumerableUpgradeable",
-                        "src": "@openzeppelin/contracts-upgradeable/token/ERC721/extensions/ERC721EnumerableUpgradeable.sol:175"
-                    },
-                    {
-                        "label": "_roles",
-                        "offset": 0,
-                        "slot": "201",
-                        "type": "t_mapping(t_bytes32,t_struct(RoleData)34_storage)",
-                        "contract": "AccessControlUpgradeable",
-                        "src": "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol:61"
-                    },
-                    {
-                        "label": "__gap",
-                        "offset": 0,
-                        "slot": "202",
-                        "type": "t_array(t_uint256)49_storage",
-                        "contract": "AccessControlUpgradeable",
-                        "src": "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol:235"
-                    },
-                    {
-                        "label": "_HASHED_NAME",
-                        "offset": 0,
-                        "slot": "251",
-                        "type": "t_bytes32",
-                        "contract": "EIP712Upgradeable",
-                        "src": "@openzeppelin/contracts-upgradeable/utils/cryptography/draft-EIP712Upgradeable.sol:30"
-                    },
-                    {
-                        "label": "_HASHED_VERSION",
-                        "offset": 0,
-                        "slot": "252",
-                        "type": "t_bytes32",
-                        "contract": "EIP712Upgradeable",
-                        "src": "@openzeppelin/contracts-upgradeable/utils/cryptography/draft-EIP712Upgradeable.sol:31"
-                    },
-                    {
-                        "label": "__gap",
-                        "offset": 0,
-                        "slot": "253",
-                        "type": "t_array(t_uint256)50_storage",
-                        "contract": "EIP712Upgradeable",
-                        "src": "@openzeppelin/contracts-upgradeable/utils/cryptography/draft-EIP712Upgradeable.sol:118"
-                    },
-                    {
-                        "label": "__gap",
-                        "offset": 0,
-                        "slot": "303",
-                        "type": "t_array(t_uint256)50_storage",
-                        "contract": "ERC1967UpgradeUpgradeable",
-                        "src": "@openzeppelin/contracts-upgradeable/proxy/ERC1967/ERC1967UpgradeUpgradeable.sol:211"
-                    },
-                    {
-                        "label": "__gap",
-                        "offset": 0,
-                        "slot": "353",
-                        "type": "t_array(t_uint256)50_storage",
-                        "contract": "UUPSUpgradeable",
-                        "src": "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol:107"
-                    },
-                    {
-                        "label": "_nonces",
-                        "offset": 0,
-                        "slot": "403",
-                        "type": "t_mapping(t_address,t_struct(Counter)4088_storage)",
-                        "contract": "ERC721PermitUpgradeable",
-                        "src": "contracts/ERC721PermitUpgradeable.sol:49"
-                    },
-                    {
-                        "label": "template",
-                        "offset": 0,
-                        "slot": "404",
-                        "type": "t_address",
-                        "contract": "VaultFactory",
-                        "src": "contracts/vault/VaultFactory.sol:39"
-                    },
-                    {
-                        "label": "whitelist",
-                        "offset": 0,
-                        "slot": "405",
-                        "type": "t_address",
-                        "contract": "VaultFactory",
-                        "src": "contracts/vault/VaultFactory.sol:41"
-                    }
-                ],
-                "types": {
-                    "t_address": {
-                        "label": "address",
-                        "numberOfBytes": "20"
-                    },
-                    "t_array(t_uint256)44_storage": {
-                        "label": "uint256[44]",
-                        "numberOfBytes": "1408"
-                    },
-                    "t_array(t_uint256)46_storage": {
-                        "label": "uint256[46]",
-                        "numberOfBytes": "1472"
-                    },
-                    "t_array(t_uint256)49_storage": {
-                        "label": "uint256[49]",
-                        "numberOfBytes": "1568"
-                    },
-                    "t_array(t_uint256)50_storage": {
-                        "label": "uint256[50]",
-                        "numberOfBytes": "1600"
-                    },
-                    "t_array(t_uint256)dyn_storage": {
-                        "label": "uint256[]",
-                        "numberOfBytes": "32"
-                    },
-                    "t_bool": {
-                        "label": "bool",
-                        "numberOfBytes": "1"
-                    },
-                    "t_bytes32": {
-                        "label": "bytes32",
-                        "numberOfBytes": "32"
-                    },
-                    "t_mapping(t_address,t_bool)": {
-                        "label": "mapping(address => bool)",
-                        "numberOfBytes": "32"
-                    },
-                    "t_mapping(t_address,t_mapping(t_address,t_bool))": {
-                        "label": "mapping(address => mapping(address => bool))",
-                        "numberOfBytes": "32"
-                    },
-                    "t_mapping(t_address,t_mapping(t_uint256,t_uint256))": {
-                        "label": "mapping(address => mapping(uint256 => uint256))",
-                        "numberOfBytes": "32"
-                    },
-                    "t_mapping(t_address,t_struct(Counter)4088_storage)": {
-                        "label": "mapping(address => struct CountersUpgradeable.Counter)",
-                        "numberOfBytes": "32"
-                    },
-                    "t_mapping(t_address,t_uint256)": {
-                        "label": "mapping(address => uint256)",
-                        "numberOfBytes": "32"
-                    },
-                    "t_mapping(t_bytes32,t_struct(RoleData)34_storage)": {
-                        "label": "mapping(bytes32 => struct AccessControlUpgradeable.RoleData)",
-                        "numberOfBytes": "32"
-                    },
-                    "t_mapping(t_uint256,t_address)": {
-                        "label": "mapping(uint256 => address)",
-                        "numberOfBytes": "32"
-                    },
-                    "t_mapping(t_uint256,t_uint256)": {
-                        "label": "mapping(uint256 => uint256)",
-                        "numberOfBytes": "32"
-                    },
-                    "t_string_storage": {
-                        "label": "string",
-                        "numberOfBytes": "32"
-                    },
-                    "t_struct(Counter)4088_storage": {
-                        "label": "struct CountersUpgradeable.Counter",
-                        "members": [
-                            {
-                                "label": "_value",
-                                "type": "t_uint256",
-                                "offset": 0,
-                                "slot": "0"
-                            }
-                        ],
-                        "numberOfBytes": "32"
-                    },
-                    "t_struct(RoleData)34_storage": {
-                        "label": "struct AccessControlUpgradeable.RoleData",
-                        "members": [
-                            {
-                                "label": "members",
-                                "type": "t_mapping(t_address,t_bool)",
-                                "offset": 0,
-                                "slot": "0"
-                            },
-                            {
-                                "label": "adminRole",
-                                "type": "t_bytes32",
-                                "offset": 0,
-                                "slot": "1"
-                            }
-                        ],
-                        "numberOfBytes": "64"
-                    },
-                    "t_uint256": {
-                        "label": "uint256",
-                        "numberOfBytes": "32"
-                    }
-                }
-            }
-        },
-        "d9f11f10b4559352ce2399a4d612f881a956026257bd23ca64eadbc459c5b0a0": {
-            "address": "0xEda9A55b5E3070754131C43C44E672463f9Aa1cd",
-            "txHash": "0x6ebf3911ca81223e4124e0e79f27fcc37a45572bf109bb21116d6c3386aeba30",
-            "layout": {
-                "storage": [
-                    {
-                        "label": "_initialized",
-                        "offset": 0,
-                        "slot": "0",
-                        "type": "t_bool",
-                        "contract": "Initializable",
-                        "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:39"
-                    },
-                    {
-                        "label": "_initializing",
-                        "offset": 1,
-                        "slot": "0",
-                        "type": "t_bool",
-                        "contract": "Initializable",
-                        "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:44"
-                    },
-                    {
-                        "label": "__gap",
-                        "offset": 0,
-                        "slot": "1",
-                        "type": "t_array(t_uint256)50_storage",
-                        "contract": "ContextUpgradeable",
-                        "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:36"
-                    },
-                    {
-                        "label": "__gap",
-                        "offset": 0,
-                        "slot": "51",
-                        "type": "t_array(t_uint256)50_storage",
-                        "contract": "ERC165Upgradeable",
-                        "src": "@openzeppelin/contracts-upgradeable/utils/introspection/ERC165Upgradeable.sol:41"
-                    },
-                    {
-                        "label": "_roles",
-                        "offset": 0,
-                        "slot": "101",
-                        "type": "t_mapping(t_bytes32,t_struct(RoleData)34_storage)",
-                        "contract": "AccessControlUpgradeable",
-                        "src": "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol:61"
-                    },
-                    {
-                        "label": "__gap",
-                        "offset": 0,
-                        "slot": "102",
-                        "type": "t_array(t_uint256)49_storage",
-                        "contract": "AccessControlUpgradeable",
-                        "src": "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol:235"
-                    },
-                    {
-                        "label": "_paused",
-                        "offset": 0,
-                        "slot": "151",
-                        "type": "t_bool",
-                        "contract": "PausableUpgradeable",
-                        "src": "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol:29"
-                    },
-                    {
-                        "label": "__gap",
-                        "offset": 0,
-                        "slot": "152",
-                        "type": "t_array(t_uint256)49_storage",
-                        "contract": "PausableUpgradeable",
-                        "src": "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol:102"
-                    },
-                    {
-                        "label": "__gap",
-                        "offset": 0,
-                        "slot": "201",
-                        "type": "t_array(t_uint256)50_storage",
-                        "contract": "ERC1967UpgradeUpgradeable",
-                        "src": "@openzeppelin/contracts-upgradeable/proxy/ERC1967/ERC1967UpgradeUpgradeable.sol:211"
-                    },
-                    {
-                        "label": "__gap",
-                        "offset": 0,
-                        "slot": "251",
-                        "type": "t_array(t_uint256)50_storage",
-                        "contract": "UUPSUpgradeable",
-                        "src": "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol:107"
-                    },
-                    {
-                        "label": "borrowerNote",
-                        "offset": 0,
-                        "slot": "301",
-                        "type": "t_contract(IPromissoryNote)19306",
-                        "contract": "LoanCore",
-                        "src": "contracts/LoanCore.sol:74"
-                    },
-                    {
-                        "label": "lenderNote",
-                        "offset": 0,
-                        "slot": "302",
-                        "type": "t_contract(IPromissoryNote)19306",
-                        "contract": "LoanCore",
-                        "src": "contracts/LoanCore.sol:75"
-                    },
-                    {
-                        "label": "feeController",
-                        "offset": 0,
-                        "slot": "303",
-                        "type": "t_contract(IFeeController)18684",
-                        "contract": "LoanCore",
-                        "src": "contracts/LoanCore.sol:76"
-                    },
-                    {
-                        "label": "loanIdTracker",
-                        "offset": 0,
-                        "slot": "304",
-                        "type": "t_struct(Counter)4088_storage",
-                        "contract": "LoanCore",
-                        "src": "contracts/LoanCore.sol:80"
-                    },
-                    {
-                        "label": "loans",
-                        "offset": 0,
-                        "slot": "305",
-                        "type": "t_mapping(t_uint256,t_struct(LoanData)19487_storage)",
-                        "contract": "LoanCore",
-                        "src": "contracts/LoanCore.sol:81"
-                    },
-                    {
-                        "label": "collateralInUse",
-                        "offset": 0,
-                        "slot": "306",
-                        "type": "t_mapping(t_bytes32,t_bool)",
-                        "contract": "LoanCore",
-                        "src": "contracts/LoanCore.sol:83"
-                    },
-                    {
-                        "label": "usedNonces",
-                        "offset": 0,
-                        "slot": "307",
-                        "type": "t_mapping(t_address,t_mapping(t_uint160,t_bool))",
-                        "contract": "LoanCore",
-                        "src": "contracts/LoanCore.sol:84"
-                    }
-                ],
-                "types": {
-                    "t_address": {
-                        "label": "address",
-                        "numberOfBytes": "20"
-                    },
-                    "t_array(t_uint256)49_storage": {
-                        "label": "uint256[49]",
-                        "numberOfBytes": "1568"
-                    },
-                    "t_array(t_uint256)50_storage": {
-                        "label": "uint256[50]",
-                        "numberOfBytes": "1600"
-                    },
-                    "t_bool": {
-                        "label": "bool",
-                        "numberOfBytes": "1"
-                    },
-                    "t_bytes32": {
-                        "label": "bytes32",
-                        "numberOfBytes": "32"
-                    },
-                    "t_contract(IFeeController)18684": {
-                        "label": "contract IFeeController",
-                        "numberOfBytes": "20"
-                    },
-                    "t_contract(IPromissoryNote)19306": {
-                        "label": "contract IPromissoryNote",
-                        "numberOfBytes": "20"
-                    },
-                    "t_enum(LoanState)19419": {
-                        "label": "enum LoanLibrary.LoanState",
-                        "members": ["DUMMY_DO_NOT_USE", "Active", "Repaid", "Defaulted"],
-                        "numberOfBytes": "1"
-                    },
-                    "t_mapping(t_address,t_bool)": {
-                        "label": "mapping(address => bool)",
-                        "numberOfBytes": "32"
-                    },
-                    "t_mapping(t_address,t_mapping(t_uint160,t_bool))": {
-                        "label": "mapping(address => mapping(uint160 => bool))",
-                        "numberOfBytes": "32"
-                    },
-                    "t_mapping(t_bytes32,t_bool)": {
-                        "label": "mapping(bytes32 => bool)",
-                        "numberOfBytes": "32"
-                    },
-                    "t_mapping(t_bytes32,t_struct(RoleData)34_storage)": {
-                        "label": "mapping(bytes32 => struct AccessControlUpgradeable.RoleData)",
-                        "numberOfBytes": "32"
-                    },
-                    "t_mapping(t_uint160,t_bool)": {
-                        "label": "mapping(uint160 => bool)",
-                        "numberOfBytes": "32"
-                    },
-                    "t_mapping(t_uint256,t_struct(LoanData)19487_storage)": {
-                        "label": "mapping(uint256 => struct LoanLibrary.LoanData)",
-                        "numberOfBytes": "32"
-                    },
-                    "t_struct(Counter)4088_storage": {
-                        "label": "struct CountersUpgradeable.Counter",
-                        "members": [
-                            {
-                                "label": "_value",
-                                "type": "t_uint256",
-                                "offset": 0,
-                                "slot": "0"
-                            }
-                        ],
-                        "numberOfBytes": "32"
-                    },
-                    "t_struct(LoanData)19487_storage": {
-                        "label": "struct LoanLibrary.LoanData",
-                        "members": [
-                            {
-                                "label": "state",
-                                "type": "t_enum(LoanState)19419",
-                                "offset": 0,
-                                "slot": "0"
-                            },
-                            {
-                                "label": "numInstallmentsPaid",
-                                "type": "t_uint24",
-                                "offset": 1,
-                                "slot": "0"
-                            },
-                            {
-                                "label": "startDate",
-                                "type": "t_uint160",
-                                "offset": 4,
-                                "slot": "0"
-                            },
-                            {
-                                "label": "terms",
-                                "type": "t_struct(LoanTerms)19441_storage",
-                                "offset": 0,
-                                "slot": "1"
-                            },
-                            {
-                                "label": "balance",
-                                "type": "t_uint256",
-                                "offset": 0,
-                                "slot": "6"
-                            },
-                            {
-                                "label": "balancePaid",
-                                "type": "t_uint256",
-                                "offset": 0,
-                                "slot": "7"
-                            },
-                            {
-                                "label": "lateFeesAccrued",
-                                "type": "t_uint256",
-                                "offset": 0,
-                                "slot": "8"
-                            }
-                        ],
-                        "numberOfBytes": "288"
-                    },
-                    "t_struct(LoanTerms)19441_storage": {
-                        "label": "struct LoanLibrary.LoanTerms",
-                        "members": [
-                            {
-                                "label": "durationSecs",
-                                "type": "t_uint32",
-                                "offset": 0,
-                                "slot": "0"
-                            },
-                            {
-                                "label": "deadline",
-                                "type": "t_uint32",
-                                "offset": 4,
-                                "slot": "0"
-                            },
-                            {
-                                "label": "numInstallments",
-                                "type": "t_uint24",
-                                "offset": 8,
-                                "slot": "0"
-                            },
-                            {
-                                "label": "interestRate",
-                                "type": "t_uint160",
-                                "offset": 11,
-                                "slot": "0"
-                            },
-                            {
-                                "label": "principal",
-                                "type": "t_uint256",
-                                "offset": 0,
-                                "slot": "1"
-                            },
-                            {
-                                "label": "collateralAddress",
-                                "type": "t_address",
-                                "offset": 0,
-                                "slot": "2"
-                            },
-                            {
-                                "label": "collateralId",
-                                "type": "t_uint256",
-                                "offset": 0,
-                                "slot": "3"
-                            },
-                            {
-                                "label": "payableCurrency",
-                                "type": "t_address",
-                                "offset": 0,
-                                "slot": "4"
-                            }
-                        ],
-                        "numberOfBytes": "160"
-                    },
-                    "t_struct(RoleData)34_storage": {
-                        "label": "struct AccessControlUpgradeable.RoleData",
-                        "members": [
-                            {
-                                "label": "members",
-                                "type": "t_mapping(t_address,t_bool)",
-                                "offset": 0,
-                                "slot": "0"
-                            },
-                            {
-                                "label": "adminRole",
-                                "type": "t_bytes32",
-                                "offset": 0,
-                                "slot": "1"
-                            }
-                        ],
-                        "numberOfBytes": "64"
-                    },
-                    "t_uint160": {
-                        "label": "uint160",
-                        "numberOfBytes": "20"
-                    },
-                    "t_uint24": {
-                        "label": "uint24",
-                        "numberOfBytes": "3"
-                    },
-                    "t_uint256": {
-                        "label": "uint256",
-                        "numberOfBytes": "32"
-                    },
-                    "t_uint32": {
-                        "label": "uint32",
-                        "numberOfBytes": "4"
-                    }
-                }
-            }
-        },
-        "8312d332c2a256ead7aac7eb0e95bc53a8a612ae40a32ee44fcc921aeba0588a": {
-            "address": "0x6eb8A6514112D6612EDeC8c658818E1F1629430A",
-            "txHash": "0xef3221147cc2666c1722432f6de6aa1bc5b8a3a693352fed5e8d42dcdac7b6a9",
-            "layout": {
-                "storage": [
-                    {
-                        "label": "_initialized",
-                        "offset": 0,
-                        "slot": "0",
-                        "type": "t_bool",
-                        "contract": "Initializable",
-                        "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:39"
-                    },
-                    {
-                        "label": "_initializing",
-                        "offset": 1,
-                        "slot": "0",
-                        "type": "t_bool",
-                        "contract": "Initializable",
-                        "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:44"
-                    },
-                    {
-                        "label": "__gap",
-                        "offset": 0,
-                        "slot": "1",
-                        "type": "t_array(t_uint256)50_storage",
-                        "contract": "ContextUpgradeable",
-                        "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:36"
-                    },
-                    {
-                        "label": "_HASHED_NAME",
-                        "offset": 0,
-                        "slot": "51",
-                        "type": "t_bytes32",
-                        "contract": "EIP712Upgradeable",
-                        "src": "@openzeppelin/contracts-upgradeable/utils/cryptography/draft-EIP712Upgradeable.sol:30"
-                    },
-                    {
-                        "label": "_HASHED_VERSION",
-                        "offset": 0,
-                        "slot": "52",
-                        "type": "t_bytes32",
-                        "contract": "EIP712Upgradeable",
-                        "src": "@openzeppelin/contracts-upgradeable/utils/cryptography/draft-EIP712Upgradeable.sol:31"
-                    },
-                    {
-                        "label": "__gap",
-                        "offset": 0,
-                        "slot": "53",
-                        "type": "t_array(t_uint256)50_storage",
-                        "contract": "EIP712Upgradeable",
-                        "src": "@openzeppelin/contracts-upgradeable/utils/cryptography/draft-EIP712Upgradeable.sol:118"
-                    },
-                    {
-                        "label": "_status",
-                        "offset": 0,
-                        "slot": "103",
-                        "type": "t_uint256",
-                        "contract": "ReentrancyGuardUpgradeable",
-                        "src": "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol:38"
-                    },
-                    {
-                        "label": "__gap",
-                        "offset": 0,
-                        "slot": "104",
-                        "type": "t_array(t_uint256)49_storage",
-                        "contract": "ReentrancyGuardUpgradeable",
-                        "src": "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol:74"
-                    },
-                    {
-                        "label": "_owner",
-                        "offset": 0,
-                        "slot": "153",
-                        "type": "t_address",
-                        "contract": "OwnableUpgradeable",
-                        "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:22"
-                    },
-                    {
-                        "label": "__gap",
-                        "offset": 0,
-                        "slot": "154",
-                        "type": "t_array(t_uint256)49_storage",
-                        "contract": "OwnableUpgradeable",
-                        "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:87"
-                    },
-                    {
-                        "label": "__gap",
-                        "offset": 0,
-                        "slot": "203",
-                        "type": "t_array(t_uint256)50_storage",
-                        "contract": "ERC1967UpgradeUpgradeable",
-                        "src": "@openzeppelin/contracts-upgradeable/proxy/ERC1967/ERC1967UpgradeUpgradeable.sol:211"
-                    },
-                    {
-                        "label": "__gap",
-                        "offset": 0,
-                        "slot": "253",
-                        "type": "t_array(t_uint256)50_storage",
-                        "contract": "UUPSUpgradeable",
-                        "src": "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol:107"
-                    },
-                    {
-                        "label": "loanCore",
-                        "offset": 0,
-                        "slot": "303",
-                        "type": "t_address",
-                        "contract": "OriginationController",
-                        "src": "contracts/OriginationController.sol:88"
-                    },
-                    {
-                        "label": "_signerApprovals",
-                        "offset": 0,
-                        "slot": "304",
-                        "type": "t_mapping(t_address,t_mapping(t_address,t_bool))",
-                        "contract": "OriginationController",
-                        "src": "contracts/OriginationController.sol:93"
-                    },
-                    {
-                        "label": "allowedVerifiers",
-                        "offset": 0,
-                        "slot": "305",
-                        "type": "t_mapping(t_address,t_bool)",
-                        "contract": "OriginationController",
-                        "src": "contracts/OriginationController.sol:95"
-                    }
-                ],
-                "types": {
-                    "t_address": {
-                        "label": "address",
-                        "numberOfBytes": "20"
-                    },
-                    "t_array(t_uint256)49_storage": {
-                        "label": "uint256[49]",
-                        "numberOfBytes": "1568"
-                    },
-                    "t_array(t_uint256)50_storage": {
-                        "label": "uint256[50]",
-                        "numberOfBytes": "1600"
-                    },
-                    "t_bool": {
-                        "label": "bool",
-                        "numberOfBytes": "1"
-                    },
-                    "t_bytes32": {
-                        "label": "bytes32",
-                        "numberOfBytes": "32"
-                    },
-                    "t_mapping(t_address,t_bool)": {
-                        "label": "mapping(address => bool)",
-                        "numberOfBytes": "32"
-                    },
-                    "t_mapping(t_address,t_mapping(t_address,t_bool))": {
-                        "label": "mapping(address => mapping(address => bool))",
-                        "numberOfBytes": "32"
-                    },
-                    "t_uint256": {
-                        "label": "uint256",
-                        "numberOfBytes": "32"
-                    }
-                }
-            }
+      }
+    },
+    "8312d332c2a256ead7aac7eb0e95bc53a8a612ae40a32ee44fcc921aeba0588a": {
+      "address": "0xa4F802ff09f5370B6601D626a65A924824dADF28",
+      "txHash": "0xcb5f652d85309da0afb63ef395c69fecab2ea32dc1b720f378ebf89b9201aa46",
+      "layout": {
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:39"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:44"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "_HASHED_NAME",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_bytes32",
+            "contract": "EIP712Upgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/cryptography/draft-EIP712Upgradeable.sol:30"
+          },
+          {
+            "label": "_HASHED_VERSION",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_bytes32",
+            "contract": "EIP712Upgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/cryptography/draft-EIP712Upgradeable.sol:31"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "53",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "EIP712Upgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/cryptography/draft-EIP712Upgradeable.sol:118"
+          },
+          {
+            "label": "_status",
+            "offset": 0,
+            "slot": "103",
+            "type": "t_uint256",
+            "contract": "ReentrancyGuardUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol:38"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "104",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "ReentrancyGuardUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol:74"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "153",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "154",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:87"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "203",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ERC1967UpgradeUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/ERC1967/ERC1967UpgradeUpgradeable.sol:211"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "253",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "UUPSUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol:107"
+          },
+          {
+            "label": "loanCore",
+            "offset": 0,
+            "slot": "303",
+            "type": "t_address",
+            "contract": "OriginationController",
+            "src": "contracts/OriginationController.sol:88"
+          },
+          {
+            "label": "_signerApprovals",
+            "offset": 0,
+            "slot": "304",
+            "type": "t_mapping(t_address,t_mapping(t_address,t_bool))",
+            "contract": "OriginationController",
+            "src": "contracts/OriginationController.sol:93"
+          },
+          {
+            "label": "allowedVerifiers",
+            "offset": 0,
+            "slot": "305",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "OriginationController",
+            "src": "contracts/OriginationController.sol:95"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_mapping(t_address,t_bool))": {
+            "label": "mapping(address => mapping(address => bool))",
+            "numberOfBytes": "32"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          }
         }
+      }
     }
+  }
 }

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -102,7 +102,7 @@ function createMainnetConfig(): NetworkUserConfig {
 
 const optimizerEnabled = process.env.DISABLE_OPTIMIZER ? false : true;
 
-const config: HardhatUserConfig = {
+export const config: HardhatUserConfig = {
     defaultNetwork: "hardhat",
     gasReporter: {
         currency: "USD",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
         "@commitlint/config-conventional": "^9.1.2",
         "@ethersproject/abstract-signer": "^5.0.6",
         "@ethersproject/bignumber": "^5.0.8",
-        "@nomiclabs/hardhat-ethers": "^2.0.1",
+        "@nomiclabs/hardhat-ethers": "^2.0.6",
         "@nomiclabs/hardhat-etherscan": "^3.0.4",
         "@nomiclabs/hardhat-waffle": "^2.0.1",
         "@openzeppelin/contracts": "4.3.2",
@@ -28,7 +28,7 @@
         "eslint-config-prettier": "^6.12.0",
         "ethereum-waffle": "^3.4.4",
         "ethereumjs-util": "^7.0.10",
-        "ethers": "^5.0.32",
+        "ethers": "^5.0.0",
         "fs-extra": "^9.0.1",
         "hardhat": "^2.0.10",
         "hardhat-contract-sizer": "^2.5.1",
@@ -91,7 +91,8 @@
         "typechain": "hardhat typechain",
         "bootstrap-with-loans": "npx hardhat --network localhost run scripts/bootstrap-state-with-loans.ts",
         "bootstrap-no-loans": "npx hardhat --network localhost run scripts/bootstrap-state-no-loans.ts",
-        "verify-contracts": "ts-node scripts/verify-contracts.ts"
+        "verify-contracts": "ts-node scripts/verify-contracts.ts",
+        "setup-roles": "ts-node scripts/utils/setup-roles.ts"
     },
     "dependencies": {
         "@openzeppelin/contracts-upgradeable": "4.5.2",

--- a/scripts/utils/setup-roles.ts
+++ b/scripts/utils/setup-roles.ts
@@ -126,14 +126,14 @@ export async function main(
     console.log(SUBSECTION_SEPARATOR);
 
     // borrowerNote grants the admin role to the admin address
-    const promissoryNoteAdminBn = await borrowerNote.connect(LOAN_CORE_ADDRESS).grantRole(ADMIN_ROLE, ADMIN_ADDRESS);
+    const promissoryNoteAdminBn = await loanCore.grantRole(ADMIN_ROLE, ADMIN_ADDRESS);
     await promissoryNoteAdminBn.wait();
 
     console.log(`borrowerNote has granted admin role: ${ADMIN_ROLE} to address: ${ADMIN_ADDRESS}`);
     console.log(SUBSECTION_SEPARATOR);
 
     // lenderNote grants the admin role to the admin address
-    const promissoryNoteAdminLn = await lenderNote.connect(LOAN_CORE_ADDRESS).grantRole(ADMIN_ROLE, ADMIN_ADDRESS);
+    const promissoryNoteAdminLn = await loanCore.grantRole(ADMIN_ROLE, ADMIN_ADDRESS);
     await promissoryNoteAdminLn.wait();
 
     console.log(`lenderNote has granted admin role: ${ADMIN_ROLE} to address: ${ADMIN_ADDRESS}`);
@@ -176,14 +176,14 @@ export async function main(
     console.log(SUBSECTION_SEPARATOR);
 
     // renounce ownership from loanCore
-    const renounceBorrowerNoteAdmin = await borrowerNote.renounceRole(ADMIN_ROLE, LOAN_CORE_ADDRESS);
+    const renounceBorrowerNoteAdmin = await loanCore.renounceRole(ADMIN_ROLE, deployer.address);
     await renounceBorrowerNoteAdmin.wait();
 
     console.log(`borrowerNote has renounced admin role.`);
-    console.log(SECTION_SEPARATOR);
+    console.log(SUBSECTION_SEPARATOR);
 
     // renounce ownership from loanCore
-    const renounceLenderNoteAdmin = await lenderNote.renounceRole(ADMIN_ROLE, LOAN_CORE_ADDRESS);
+    const renounceLenderNoteAdmin = await loanCore.renounceRole(ADMIN_ROLE, deployer.address);
     await renounceLenderNoteAdmin.wait();
 
     console.log(`lenderNote has renounced admin role.`);

--- a/scripts/utils/setup-roles.ts
+++ b/scripts/utils/setup-roles.ts
@@ -126,14 +126,14 @@ export async function main(
     console.log(SUBSECTION_SEPARATOR);
 
     // borrowerNote grants the admin role to the admin address
-    const promissoryNoteAdminBn = await borrowerNote.grantRole(ADMIN_ROLE, ADMIN_ADDRESS);
+    const promissoryNoteAdminBn = await borrowerNote.connect(LOAN_CORE_ADDRESS).grantRole(ADMIN_ROLE, ADMIN_ADDRESS);
     await promissoryNoteAdminBn.wait();
 
     console.log(`borrowerNote has granted admin role: ${ADMIN_ROLE} to address: ${ADMIN_ADDRESS}`);
     console.log(SUBSECTION_SEPARATOR);
 
     // lenderNote grants the admin role to the admin address
-    const promissoryNoteAdminLn = await lenderNote.grantRole(ADMIN_ROLE, ADMIN_ADDRESS);
+    const promissoryNoteAdminLn = await lenderNote.connect(LOAN_CORE_ADDRESS).grantRole(ADMIN_ROLE, ADMIN_ADDRESS);
     await promissoryNoteAdminLn.wait();
 
     console.log(`lenderNote has granted admin role: ${ADMIN_ROLE} to address: ${ADMIN_ADDRESS}`);
@@ -175,13 +175,15 @@ export async function main(
     console.log(`vaultFactory has renounced admin role.`);
     console.log(SUBSECTION_SEPARATOR);
 
-    const renounceBorrowerNoteAdmin = await borrowerNote.renounceRole(ADMIN_ROLE, deployer.address);
+    // renounce ownership from loanCore
+    const renounceBorrowerNoteAdmin = await borrowerNote.renounceRole(ADMIN_ROLE, LOAN_CORE_ADDRESS);
     await renounceBorrowerNoteAdmin.wait();
 
     console.log(`borrowerNote has renounced admin role.`);
     console.log(SECTION_SEPARATOR);
 
-    const renounceLenderNoteAdmin = await lenderNote.renounceRole(ADMIN_ROLE, deployer.address);
+    // renounce ownership from loanCore
+    const renounceLenderNoteAdmin = await lenderNote.renounceRole(ADMIN_ROLE, LOAN_CORE_ADDRESS);
     await renounceLenderNoteAdmin.wait();
 
     console.log(`lenderNote has renounced admin role.`);

--- a/scripts/utils/setup-roles.ts
+++ b/scripts/utils/setup-roles.ts
@@ -6,7 +6,7 @@ import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 // This is imported to extend into this file: import "@nomiclabs/hardhat-ethers";
 import { config } from "../../hardhat.config";
 
-import { SECTION_SEPARATOR } from "./bootstrap-tools";
+import { SUBSECTION_SEPARATOR, SECTION_SEPARATOR } from "./bootstrap-tools";
 
 import {
     ORIGINATOR_ROLE as DEFAULT_ORIGINATOR_ROLE,
@@ -94,38 +94,59 @@ export async function main(
         await note.initialize(LOAN_CORE_ADDRESS);
     }
 
+    console.log(`borrowerNote and lenderNote have initalized loanCore at address: ${LOAN_CORE_ADDRESS}`);
+    console.log(SUBSECTION_SEPARATOR);
+
     // grant LoanCore the admin role to enable authorizeUpgrade onlyRole(DEFAULT_ADMIN_ROLE)
     const updateLoanCoreAdmin = await loanCore.grantRole(ADMIN_ROLE, ADMIN_ADDRESS);
     await updateLoanCoreAdmin.wait();
 
     console.log(`loanCore has granted admin role: ${ADMIN_ROLE} to address: ${ADMIN_ADDRESS}`);
+    console.log(SUBSECTION_SEPARATOR);
 
     // grant LoanCore admin fee claimer permissions
     const updateLoanCoreFeeClaimer = await loanCore.grantRole(FEE_CLAIMER_ROLE, ADMIN_ADDRESS);
     await updateLoanCoreFeeClaimer.wait();
 
     console.log(`loanCore has granted fee claimer role: ${FEE_CLAIMER_ROLE} to address: ${ADMIN_ADDRESS}`);
+    console.log(SUBSECTION_SEPARATOR);
 
     // grant VaultFactory the admin role to enable authorizeUpgrade onlyRole(DEFAULT_ADMIN_ROLE)
     const updateVaultFactoryAdmin = await factory.grantRole(ADMIN_ROLE, ADMIN_ADDRESS);
     await updateVaultFactoryAdmin.wait();
 
     console.log(`vaultFactory has granted admin role: ${ADMIN_ROLE} to address: ${ADMIN_ADDRESS}`);
+    console.log(SUBSECTION_SEPARATOR);
 
     // grant originationContoller the owner role to enable authorizeUpgrade onlyOwner
     const updateOriginationControllerAdmin = await loanCore.grantRole(ADMIN_ROLE, ADMIN_ADDRESS);
     await updateOriginationControllerAdmin.wait();
 
     console.log(`originationController has granted admin role: ${ADMIN_ROLE} to address: ${ADMIN_ADDRESS}`);
+    console.log(SUBSECTION_SEPARATOR);
+
+    // borrowerNote grants the admin role to the admin address
+    const promissoryNoteAdminBn = await borrowerNote.grantRole(ADMIN_ROLE, ADMIN_ADDRESS);
+    await promissoryNoteAdminBn.wait();
+
+    console.log(`borrowerNote has granted admin role: ${ADMIN_ROLE} to address: ${ADMIN_ADDRESS}`);
+    console.log(SUBSECTION_SEPARATOR);
+
+    // lenderNote grants the admin role to the admin address
+    const promissoryNoteAdminLn = await lenderNote.grantRole(ADMIN_ROLE, ADMIN_ADDRESS);
+    await promissoryNoteAdminLn.wait();
+
+    console.log(`lenderNote has granted admin role: ${ADMIN_ROLE} to address: ${ADMIN_ADDRESS}`);
+    console.log(SUBSECTION_SEPARATOR);
 
     // grant originationContoller the originator role
-    const updateOriginationControllerRole = await loanCore
-        .grantRole(ORIGINATOR_ROLE, ORIGINATION_CONTROLLER_ADDRESS);
+    const updateOriginationControllerRole = await loanCore.grantRole(ORIGINATOR_ROLE, ORIGINATION_CONTROLLER_ADDRESS);
     await updateOriginationControllerRole.wait();
 
     console.log(
         `originationController has granted originator role: ${ORIGINATOR_ROLE} to address: ${ORIGINATION_CONTROLLER_ADDRESS}`,
     );
+    console.log(SUBSECTION_SEPARATOR);
 
     // grant repaymentContoller the REPAYER_ROLE
     const updateRepaymentControllerAdmin = await loanCore
@@ -140,16 +161,30 @@ export async function main(
     await renounceAdmin.wait();
 
     console.log(`loanCore has renounced admin role.`);
+    console.log(SUBSECTION_SEPARATOR);
 
     const renounceOriginationControllerAdmin = await loanCore.renounceRole(ADMIN_ROLE, deployer.address);
     await renounceOriginationControllerAdmin.wait();
 
     console.log(`originationController has renounced originator role.`);
+    console.log(SUBSECTION_SEPARATOR);
 
     const renounceVaultFactoryAdmin = await factory.renounceRole(ADMIN_ROLE, deployer.address);
     await renounceVaultFactoryAdmin.wait();
 
     console.log(`vaultFactory has renounced admin role.`);
+    console.log(SUBSECTION_SEPARATOR);
+
+    const renounceBorrowerNoteAdmin = await borrowerNote.renounceRole(ADMIN_ROLE, deployer.address);
+    await renounceBorrowerNoteAdmin.wait();
+
+    console.log(`borrowerNote has renounced admin role.`);
+    console.log(SECTION_SEPARATOR);
+
+    const renounceLenderNoteAdmin = await lenderNote.renounceRole(ADMIN_ROLE, deployer.address);
+    await renounceLenderNoteAdmin.wait();
+
+    console.log(`lenderNote has renounced admin role.`);
     console.log(SECTION_SEPARATOR);
 
     if (FEE_CONTROLLER_ADDRESS) {
@@ -160,6 +195,7 @@ export async function main(
     }
 
     console.log(`feeController has transferred ownership to address: ${ADMIN_ADDRESS}`);
+    console.log(SUBSECTION_SEPARATOR);
 
     if (CALL_WHITELIST_ADDRESS) {
         // set CallWhiteList admin
@@ -169,8 +205,8 @@ export async function main(
     }
 
     console.log(`whitelist has transferred ownership to address: ${ADMIN_ADDRESS}`);
-
     console.log(SECTION_SEPARATOR);
+
     console.log("Transferred all ownership.\n");
 }
 

--- a/scripts/utils/setup-roles.ts
+++ b/scripts/utils/setup-roles.ts
@@ -68,9 +68,6 @@ export async function main(
     const ORIGINATOR_ROLE = DEFAULT_ORIGINATOR_ROLE;
     const REPAYER_ROLE = DEFAULT_REPAYER_ROLE;
 
-    const VAULT_FACTORY_ADDRESS = factory.address;
-    const LENDER_NOTE_ADDRESS = lenderNote.address;
-    const BORROWER_NOTE_ADDRESS = borrowerNote.address;
     const ORIGINATION_CONTROLLER_ADDRESS = originationController.address;
     const LOAN_CORE_ADDRESS = loanCore.address;
     const FEE_CONTROLLER_ADDRESS = feeController.address;
@@ -91,59 +88,39 @@ export async function main(
 
     console.log(SECTION_SEPARATOR);
 
-    loanCore = await ethers.getContractAt("LoanCore", LOAN_CORE_ADDRESS);
-    factory = await ethers.getContractAt("VaultFactory", VAULT_FACTORY_ADDRESS);
-    lenderNote = await ethers.getContractAt("PromissoryNote", LENDER_NOTE_ADDRESS);
-    borrowerNote = await ethers.getContractAt("PromissoryNote", BORROWER_NOTE_ADDRESS);
-
-    const gasLimit = 300000;
-
     // grant correct permissions for promissory note
     // giving to user to call PromissoryNote functions directly
     for (const note of [borrowerNote, lenderNote]) {
-        await note.connect(deployer).initialize(loanCore.address, {
-            gasLimit
-        });
+        await note.connect(deployer).initialize("0xB6Bd97421564030a5018DD6d0Fc4a362b8228B82");
     }
 
     // grant LoanCore the admin role to enable authorizeUpgrade onlyRole(DEFAULT_ADMIN_ROLE)
-    const updateLoanCoreAdmin = await loanCore.grantRole(ADMIN_ROLE, ADMIN_ADDRESS, {
-        gasLimit
-    });
+    const updateLoanCoreAdmin = await loanCore.grantRole(ADMIN_ROLE, ADMIN_ADDRESS);
     await updateLoanCoreAdmin.wait();
 
     console.log(`loanCore has granted admin role: ${ADMIN_ROLE} to address: ${ADMIN_ADDRESS}`);
 
     // grant LoanCore admin fee claimer permissions
-    const updateLoanCoreFeeClaimer = await loanCore.grantRole(FEE_CLAIMER_ROLE, ADMIN_ADDRESS, {
-        gasLimit
-    });
+    const updateLoanCoreFeeClaimer = await loanCore.grantRole(FEE_CLAIMER_ROLE, ADMIN_ADDRESS);
     await updateLoanCoreFeeClaimer.wait();
 
     console.log(`loanCore has granted fee claimer role: ${FEE_CLAIMER_ROLE} to address: ${ADMIN_ADDRESS}`);
 
     // grant VaultFactory the admin role to enable authorizeUpgrade onlyRole(DEFAULT_ADMIN_ROLE)
-    const updateVaultFactoryAdmin = await factory.grantRole(ADMIN_ROLE, ADMIN_ADDRESS, {
-        gasLimit
-    });
+    const updateVaultFactoryAdmin = await factory.grantRole(ADMIN_ROLE, ADMIN_ADDRESS);
     await updateVaultFactoryAdmin.wait();
 
     console.log(`vaultFactory has granted admin role: ${ADMIN_ROLE} to address: ${ADMIN_ADDRESS}`);
 
     // grant originationContoller the owner role to enable authorizeUpgrade onlyOwner
-    const updateOriginationControllerAdmin = await loanCore.connect(deployer).grantRole(ADMIN_ROLE, ADMIN_ADDRESS, {
-        gasLimit
-    });
+    const updateOriginationControllerAdmin = await loanCore.grantRole(ADMIN_ROLE, ADMIN_ADDRESS);
     await updateOriginationControllerAdmin.wait();
 
     console.log(`originationController has granted admin role: ${ADMIN_ROLE} to address: ${ADMIN_ADDRESS}`);
 
     // grant originationContoller the originator role
     const updateOriginationControllerRole = await loanCore
-        .connect(deployer)
-        .grantRole(ORIGINATOR_ROLE, ORIGINATION_CONTROLLER_ADDRESS, {
-            gasLimit
-        });
+        .grantRole(ORIGINATOR_ROLE, ORIGINATION_CONTROLLER_ADDRESS);
     await updateOriginationControllerRole.wait();
 
     console.log(
@@ -152,33 +129,24 @@ export async function main(
 
     // grant repaymentContoller the REPAYER_ROLE
     const updateRepaymentControllerAdmin = await loanCore
-        .connect(deployer)
-        .grantRole(REPAYER_ROLE, REPAYMENT_CONTROLLER_ADDRESS, {
-            gasLimit
-        });
+        .grantRole(REPAYER_ROLE, REPAYMENT_CONTROLLER_ADDRESS);
     await updateRepaymentControllerAdmin.wait();
 
     console.log(`loanCore has granted repayer role: ${REPAYER_ROLE} to address: ${REPAYMENT_CONTROLLER_ADDRESS}`);
     console.log(SECTION_SEPARATOR);
 
     // renounce ownership from deployer
-    const renounceAdmin = await loanCore.renounceRole(ADMIN_ROLE, await deployer.address, {
-        gasLimit
-    });
+    const renounceAdmin = await loanCore.renounceRole(ADMIN_ROLE, await deployer.address);
     await renounceAdmin.wait();
 
     console.log(`loanCore has renounced admin role.`);
 
-    const renounceOriginationControllerAdmin = await loanCore.renounceRole(ADMIN_ROLE, await deployer.address, {
-        gasLimit
-    });
+    const renounceOriginationControllerAdmin = await loanCore.renounceRole(ADMIN_ROLE, deployer.address);
     await renounceOriginationControllerAdmin.wait();
 
     console.log(`originationController has renounced originator role.`);
 
-    const renounceVaultFactoryAdmin = await factory.renounceRole(ADMIN_ROLE, await deployer.address, {
-        gasLimit
-    });
+    const renounceVaultFactoryAdmin = await factory.renounceRole(ADMIN_ROLE, deployer.address);
     await renounceVaultFactoryAdmin.wait();
 
     console.log(`vaultFactory has renounced admin role.`);

--- a/scripts/utils/setup-roles.ts
+++ b/scripts/utils/setup-roles.ts
@@ -91,7 +91,7 @@ export async function main(
     // grant correct permissions for promissory note
     // giving to user to call PromissoryNote functions directly
     for (const note of [borrowerNote, lenderNote]) {
-        await note.connect(deployer).initialize("0xB6Bd97421564030a5018DD6d0Fc4a362b8228B82");
+        await note.initialize(LOAN_CORE_ADDRESS);
     }
 
     // grant LoanCore the admin role to enable authorizeUpgrade onlyRole(DEFAULT_ADMIN_ROLE)


### PR DESCRIPTION
- Incorporated only multisig address (0x02C845ac4baC48A6CD1e1c88a84195B7d5805B82) vs. an admin address and a multisig address.
- Included the previously removed code for granting admin role to _authorizeUpgrade of upgradeable contracts
- `setup-role.ts` can now be run from the command line per this example:
`HARDHAT_NETWORK=rinkeby npm run setup-roles rinkeby 1655257904185000`
(testnet and timestamp are the in name of the json generated with every new deployment in `.deployments/network/deployJson`)